### PR TITLE
feat(client): implement Client CRUD operations - closes #3

### DIFF
--- a/docs/daily_logs/2026-03-31.md
+++ b/docs/daily_logs/2026-03-31.md
@@ -8,16 +8,16 @@
 
 **Concepts encountered, need deeper study:**
 
-`std::stringstream`: in-memory stream with the same `<<` and `>>` interface as cout/cin. `std::hex` manipulator formats subsequent integers as hexadecimal. `.str()` extracts the accumulated string. No flushing needed — entirely in memory. Study: other stream manipulators (`std::setw`, `std::setfill`), when to prefer stringstream over direct string building.
+`std::stringstream`: in-memory stream with the same `<<` and `>>` interface as cout/cin. `std::hex` manipulator formats subsequent integers as hexadecimal. `.str()` extracts the accumulated string. No flushing needed, entirely in memory. Study: other stream manipulators (`std::setw`, `std::setfill`), when to prefer stringstream over direct string building.
 
-`std::random_device` / `std::mt19937`: random_device reads OS entropy, mt19937 is the generator algorithm seeded from it. `static` locals initialised once for performance. Study: why mt19937 specifically, what Mersenne Twister means, other generator options.
+`std::random_device` / `std::mt19937`: random_device reads OS entropy, mt19937 is the generator algorithm seeded from it. `static` locals initialised once for performance.
 
-`std::uniform_int_distribution`: maps raw generator output into a range with equal probability. Internally uses rejection sampling to avoid modulo bias. Study: other distribution types (normal, bernoulli).
+`std::uniform_int_distribution`: maps raw generator output into a range with equal probability. Internally uses rejection sampling to avoid modulo bias. 
 
-`static` local variables: initialised once on first call, shared across all subsequent calls. More efficient than recreating objects per call. Not thread-safe when shared state is mutated — flagged for Milestone 3.
+`static` local variables: initialised once on first call, shared across all subsequent calls. More efficient than recreating objects per call. Not thread-safe when shared state is mutated, flagged for Milestone 3.
 
 Bitwise operations: `& 0x3` zeros top two bits, `| 0x8` forces top bit to 1. Used to constrain the UUID variant byte to `8`, `9`, `a`, `b` per RFC 4122. Study: bitwise operations in general if not already solid.
 
 Exceptions: constructors have no return value so they throw on invariant violations. `std::invalid_argument` for bad input. Caller wraps in `try/catch`. Study: exception hierarchy (`std::exception`, `std::runtime_error`, `std::invalid_argument`), when to use exceptions vs other error handling, `noexcept`.
 
-**Next step:** implement `client.cpp` — constructor with validation and all accessors.
+**Next step:** implement `client.cpp` constructor with validation and all accessors.

--- a/docs/daily_logs/2026-03-31.md
+++ b/docs/daily_logs/2026-03-31.md
@@ -1,0 +1,23 @@
+****March 31, 2026**
+
+**Branch:** feature/3-client-crud
+**Issue:** #3 Implement Client CRUD
+
+**What I built:**
+- `uuid.hpp` / `uuid.cpp`: UUID v4 generator using std::stringstream and std::mt19937
+
+**Concepts encountered, need deeper study:**
+
+`std::stringstream`: in-memory stream with the same `<<` and `>>` interface as cout/cin. `std::hex` manipulator formats subsequent integers as hexadecimal. `.str()` extracts the accumulated string. No flushing needed — entirely in memory. Study: other stream manipulators (`std::setw`, `std::setfill`), when to prefer stringstream over direct string building.
+
+`std::random_device` / `std::mt19937`: random_device reads OS entropy, mt19937 is the generator algorithm seeded from it. `static` locals initialised once for performance. Study: why mt19937 specifically, what Mersenne Twister means, other generator options.
+
+`std::uniform_int_distribution`: maps raw generator output into a range with equal probability. Internally uses rejection sampling to avoid modulo bias. Study: other distribution types (normal, bernoulli).
+
+`static` local variables: initialised once on first call, shared across all subsequent calls. More efficient than recreating objects per call. Not thread-safe when shared state is mutated — flagged for Milestone 3.
+
+Bitwise operations: `& 0x3` zeros top two bits, `| 0x8` forces top bit to 1. Used to constrain the UUID variant byte to `8`, `9`, `a`, `b` per RFC 4122. Study: bitwise operations in general if not already solid.
+
+Exceptions: constructors have no return value so they throw on invariant violations. `std::invalid_argument` for bad input. Caller wraps in `try/catch`. Study: exception hierarchy (`std::exception`, `std::runtime_error`, `std::invalid_argument`), when to use exceptions vs other error handling, `noexcept`.
+
+**Next step:** implement `client.cpp` — constructor with validation and all accessors.

--- a/docs/daily_logs/2026-04-02.md
+++ b/docs/daily_logs/2026-04-02.md
@@ -10,7 +10,7 @@ The function returns the current local time as a formatted string in `YYYY-MM-DD
 
 The flow is: capture the current time point with `system_clock::now()`, convert to `time_t` (seconds since Unix epoch) so the C-style calendar functions can work with it, decompose into a `tm` struct with `localtime` which breaks the raw seconds into year/month/day/hour/minute/second fields adjusted for the local timezone, then write into a `std::ostringstream` using `std::put_time` with the format string. The stream is the bridge because `put_time` only knows how to write to a stream, not directly to a string.
 
-The function is named `currentTimestamp()` rather than `createdDate()` because it serves both `created_at_` and `updated_at_` — any field that needs the current moment calls the same function.
+The function is named `currentTimestamp()` rather than `createdDate()` because it serves both `created_at_` and `updated_at_`, any field that needs the current moment calls the same function.
 
 **What I learned:**
 - `std::move` does not move memory, it casts an lvalue to an rvalue reference (`std::string&&`) giving permission for the move constructor to steal the internal buffer. The actual transfer happens in the constructor, not at the `std::move` call.
@@ -19,4 +19,4 @@ The function is named `currentTimestamp()` rather than `createdDate()` because i
 - `std::put_time` is a stream manipulator that formats a `tm` struct according to a format string — requires a stream as target, not a string directly
 - `std::ostringstream` is the bridge between stream manipulators and `std::string`
 
-**Next step:** complete `client.cpp` — implement all getters, setters, `updated_at_` logic, `lead_status_` initialisation, then move `currentTimestamp()` to utils.
+**Next step:** complete `client.cpp`, implement all getters, setters, `updated_at_` logic, `lead_status_` initialisation, then move `currentTimestamp()` to utils.

--- a/docs/daily_logs/2026-04-02.md
+++ b/docs/daily_logs/2026-04-02.md
@@ -1,0 +1,22 @@
+**April 2, 2026 -> March 31, 2026 (continued)**
+
+**What I built:**
+- `client.cpp`: constructor with validation (empty first name, empty email, regex email format), uuid generation, timestamp on creation, std::move for field assignment
+- `currentTimestamp()` utility function using std::chrono and std::put_time
+
+**Why I designed currentTimestamp() this way:**
+
+The function returns the current local time as a formatted string in `YYYY-MM-DD HH:MM:SS` format. I chose `std::chrono::system_clock` over the simpler `ctime()` approach because it gives explicit control over the output format and avoids the trailing newline that `ctime()` appends automatically.
+
+The flow is: capture the current time point with `system_clock::now()`, convert to `time_t` (seconds since Unix epoch) so the C-style calendar functions can work with it, decompose into a `tm` struct with `localtime` which breaks the raw seconds into year/month/day/hour/minute/second fields adjusted for the local timezone, then write into a `std::ostringstream` using `std::put_time` with the format string. The stream is the bridge because `put_time` only knows how to write to a stream, not directly to a string.
+
+The function is named `currentTimestamp()` rather than `createdDate()` because it serves both `created_at_` and `updated_at_` — any field that needs the current moment calls the same function.
+
+**What I learned:**
+- `std::move` does not move memory, it casts an lvalue to an rvalue reference (`std::string&&`) giving permission for the move constructor to steal the internal buffer. The actual transfer happens in the constructor, not at the `std::move` call.
+- `time_t` is seconds since Unix epoch, a raw integer not human-readable
+- `std::localtime` decomposes `time_t` into a `tm` struct with individual calendar fields, adjusted for local timezone. `gmtime` gives UTC instead.
+- `std::put_time` is a stream manipulator that formats a `tm` struct according to a format string — requires a stream as target, not a string directly
+- `std::ostringstream` is the bridge between stream manipulators and `std::string`
+
+**Next step:** complete `client.cpp` — implement all getters, setters, `updated_at_` logic, `lead_status_` initialisation, then move `currentTimestamp()` to utils.

--- a/docs/daily_logs/2026-04-03.md
+++ b/docs/daily_logs/2026-04-03.md
@@ -1,0 +1,16 @@
+**April 3, 2026**
+
+**Branch:** feature/3-client-crud
+**Issue:** #3 Implement Client CRUD: add, list, search, edit, delete
+
+**What I built:**
+- `client.hpp` / `client.cpp`: added getters for all attributes, pass-by-value + `std::move` pattern applied to all setters, `updated_at_` tracking on every setter, `isNumber()` validator using `std::find_if` and lambda
+
+**What I learned:**
+- Cannot `std::move` from `const&` — stealing the buffer is a modification, which violates the const contract. Compiler silently falls back to a copy. Correct pattern: accept by value, then move into the member.
+- `enum class` is strongly typed, no implicit conversion from `int`. Menu-to-enum mapping belongs in the CLI layer, not in domain setters.
+- `std::find_if(begin, end, predicate)` returns an iterator to the first matching element or `end` if none found. Algorithm dereferences internally — predicate receives the value directly.
+- Iterators are pointer-like values. `begin()` points to the first element, `end()` points one past the last — never dereference `end()`.
+- `str.at(i)` checks bounds and throws, `str[i]` is unchecked UB if out of bounds.
+
+**Next session:** implement `CsvClientRepository` and `ClientService` — data and service layers for the client side.

--- a/docs/daily_logs/2026-04-03.md
+++ b/docs/daily_logs/2026-04-03.md
@@ -7,10 +7,10 @@
 - `client.hpp` / `client.cpp`: added getters for all attributes, pass-by-value + `std::move` pattern applied to all setters, `updated_at_` tracking on every setter, `isNumber()` validator using `std::find_if` and lambda
 
 **What I learned:**
-- Cannot `std::move` from `const&` — stealing the buffer is a modification, which violates the const contract. Compiler silently falls back to a copy. Correct pattern: accept by value, then move into the member.
+- Cannot `std::move` from `const&`, stealing the buffer is a modification, which violates the const contract. Compiler silently falls back to a copy. Correct pattern: accept by value, then move into the member.
 - `enum class` is strongly typed, no implicit conversion from `int`. Menu-to-enum mapping belongs in the CLI layer, not in domain setters.
 - `std::find_if(begin, end, predicate)` returns an iterator to the first matching element or `end` if none found. Algorithm dereferences internally — predicate receives the value directly.
-- Iterators are pointer-like values. `begin()` points to the first element, `end()` points one past the last — never dereference `end()`.
+- Iterators are pointer-like values. `begin()` points to the first element, `end()` points one past the last, never dereference `end()`.
 - `str.at(i)` checks bounds and throws, `str[i]` is unchecked UB if out of bounds.
 
 **Next session:** implement `CsvClientRepository` and `ClientService` — data and service layers for the client side.

--- a/docs/daily_logs/2026-04-08.md
+++ b/docs/daily_logs/2026-04-08.md
@@ -1,22 +1,21 @@
-# Session recap — File I/O and string splitting
+# File I/O and string splitting
 
 ## What was covered
 
 ### File streams
-- std::ifstream for reading, std::ofstream for writing
-- Two equivalent forms for opening: constructor vs open()
-- Stream state checking with is_open() and boolean conversion
-- Reading line by line with std::getline(file, line)
-- Writing with the << operator
+- `std::ifstream` for reading, `std::ofstream` for writing
+- Two equivalent forms for opening: constructor vs `open()`
+- Stream state checking with `is_open()` and boolean conversion
+- Reading line by line with `std::getline(file, line)`
+- Writing with the `<<` operator
 - RAII: destructor closes the file automatically
 - When a dedicated RaiiFileHandle wrapper adds value over raw streams
 
 ### String splitting
 - Manual find + erase loop: works but requires explicit last-field handling
-- Stringstream approach: wraps a string in a stream interface, handles
-  all fields uniformly including the last
+- Stringstream approach: wraps a string in a stream interface, handles all fields uniformly including the last
 - Combined pattern: outer getline for rows, inner getline for fields
-- std::string::npos as the sentinel value for "not found"
+- `std::string::npos` as the sentinel value for "not found"
 
 ## What was implemented
 - Writing clients to CSV with ofstream and 
@@ -26,10 +25,10 @@
 
 ## What is not yet done
 - Full round-trip: save vector of clients, load back, reconstruct objects
-- This requires vectors — deferred to next session
+- This requires vectors, deferred to next session
 
 ## Next step
-Study std::vector operations, then implement the full round-trip in
+Study `std::vector` operations, then implement the full round-trip in
 the scratch file, then move to the real CsvClientRepository.
 
 Remember to use anonymous namespaces for static functions withing a file since is a C++ pattern. In the `client.cpp` file I used `static` that is a C pattern.

--- a/docs/daily_logs/2026-04-08.md
+++ b/docs/daily_logs/2026-04-08.md
@@ -1,0 +1,35 @@
+# Session recap — File I/O and string splitting
+
+## What was covered
+
+### File streams
+- std::ifstream for reading, std::ofstream for writing
+- Two equivalent forms for opening: constructor vs open()
+- Stream state checking with is_open() and boolean conversion
+- Reading line by line with std::getline(file, line)
+- Writing with the << operator
+- RAII: destructor closes the file automatically
+- When a dedicated RaiiFileHandle wrapper adds value over raw streams
+
+### String splitting
+- Manual find + erase loop: works but requires explicit last-field handling
+- Stringstream approach: wraps a string in a stream interface, handles
+  all fields uniformly including the last
+- Combined pattern: outer getline for rows, inner getline for fields
+- std::string::npos as the sentinel value for "not found"
+
+## What was implemented
+- Writing clients to CSV with ofstream and 
+- Reading line by line with getline
+- Manual find+erase split (hit last-field bug, understood the cause)
+- Stringstream split (written and verified correct output)
+
+## What is not yet done
+- Full round-trip: save vector of clients, load back, reconstruct objects
+- This requires vectors — deferred to next session
+
+## Next step
+Study std::vector operations, then implement the full round-trip in
+the scratch file, then move to the real CsvClientRepository.
+
+Remember to use anonymous namespaces for static functions withing a file since is a C++ pattern. In the `client.cpp` file I used `static` that is a C pattern.

--- a/docs/daily_logs/2026-04-09.md
+++ b/docs/daily_logs/2026-04-09.md
@@ -1,0 +1,57 @@
+**April 9, 2026**
+
+**Active branch:** feature/3-client-crud
+**Issue:** #3
+
+**What I built:**
+- Scratch `ClientRepository` in a single file with `addClient`, `saveClients`, `loadClients`, `printClients`
+- Working CSV round-trip: write clients to file, read back, reconstruct objects using the two-constructor pattern
+- Verified stringstream field parsing handles all fields including the last correctly
+- `FileHandler` class implementing RAII for file streams — constructor opens and throws `std::runtime_error` if file cannot be opened, destructor closes automatically
+- `getStream()` getter providing controlled access to the underlying `std::fstream` without transferring ownership
+- Adopted `git add <file>` instead of `git add .` for atomic, logically coherent commits
+
+**What I learned:**
+- `std::vector` stores elements contiguously. Reallocation on `push_back` invalidates all pointers and iterators into the vector. Directly affects the future `unordered_map` index design.
+- Erase-remove idiom: `remove_if` rearranges using move semantics, `erase` deallocates. Two steps because the standard library separates rearranging from deallocation. O(n) total, versus O(n²) for a loop with individual erases.
+- A predicate is any callable that returns `bool` and has no side effects. Term comes from formal logic. Used by `remove_if`, `find_if`, `count_if` and others.
+- Range loop conventions: `const auto&` by default, `auto&` only when modifying in place, `auto` by value is rare and expensive.
+- File streams implement RAII. Destructor closes automatically. Explicit `close()` is redundant. `FileHandler` earns its place not for closing but for the throwing constructor — making invalid state impossible.
+- `std::string&` cannot bind to a string literal (rvalue). Use `const std::string&` or pass by value.
+- CSV loading requires a second constructor that accepts UUID as a parameter. Regenerating UUIDs on load would break referential integrity with policies and interactions.
+- How to read function signatures in documentation: template parameters describe what the compiler deduces, `begin()` and `end()` do the deduction work at the call site, parameter names in docs are descriptive not prescriptive.
+- `std::nullopt` is the idiomatic return value for an empty `std::optional`. `has_value()` is the explicit check, `if (!result)` is the concise form.
+- `getStream()` cannot be `const` because using a stream modifies internal state — cursor advances, error flags can change.
+- Accepting `std::ios::openmode` directly instead of a mode string eliminates branching entirely. No string comparison, no magic strings, compiler catches invalid modes.
+
+**Architecture reasoning:**
+
+The in-memory vector is a CSV-specific implementation detail, not a universal repository pattern. For production databases the engine handles caching internally. `SqlClientRepository` would have no vector, just queries. This validates the abstraction: `IClientRepository` stays identical when moving from CSV to SQL, only the implementation changes.
+
+The vector belongs in `CsvClientRepository`, not in `ClientService`. The service calls the interface and never touches the vector directly. The composition root instantiates the concrete repository and injects it into the service. The `dirty_` flag lives in the repository and is invisible above that boundary.
+
+`FileHandler` responsibility is narrow: ensure the file resource is in a valid open state and release it when done. Path validity and format checking belong to the caller.
+
+**Ownership and return type decisions:**
+
+`findAll` returns `const std::vector<Client>&` directly, a reference into the repository's internal vector. No copy, no allocation. The caller receives read-only access and uses it immediately for display. Ownership stays with the repository.
+
+`findByUuid` and `findByEmail` return `std::optional<Client>` by value. They cannot return a reference because `std::optional` cannot hold references in C++17, and because the referenced element could be invalidated by vector reallocation. Rule: return `const&` only when returning something that already exists with a lifetime tied to the owning object.
+
+`IClientRepository` updated accordingly:
+
+```cpp
+virtual const std::vector<Client>& findAll() const = 0;
+virtual std::optional<Client> findByUuid(const std::string& uuid) const = 0;
+virtual std::optional<Client> findByEmail(const std::string& email) const = 0;
+```
+
+**Decision — in-memory storage:**
+
+Version 1 uses `std::vector<Client>`. O(n) search is acceptable for the current dataset size. Evaluating `std::unordered_map` as a secondary index for future improvement: O(1) lookup for `findByEmail` and `findByUuid` at the cost of index maintenance on every mutation. Will document as a formal ADR when implementing `ClientService`.
+
+**Blockers / open questions:**
+- Optional fields: empty string as sentinel, no special constructor needed. `std::optional<std::string>` refactor deferred to after the CSV repository is complete.
+
+**Next session:**
+Implement `load()` and `save()` in `CsvClientRepository` using `FileHandler`. Start with `serialize()` and `deserialize()` private helpers, then wire them into the two persistence methods.

--- a/docs/daily_logs/2026-04-09.md
+++ b/docs/daily_logs/2026-04-09.md
@@ -19,7 +19,6 @@
 - File streams implement RAII. Destructor closes automatically. Explicit `close()` is redundant. `FileHandler` earns its place not for closing but for the throwing constructor — making invalid state impossible.
 - `std::string&` cannot bind to a string literal (rvalue). Use `const std::string&` or pass by value.
 - CSV loading requires a second constructor that accepts UUID as a parameter. Regenerating UUIDs on load would break referential integrity with policies and interactions.
-- How to read function signatures in documentation: template parameters describe what the compiler deduces, `begin()` and `end()` do the deduction work at the call site, parameter names in docs are descriptive not prescriptive.
 - `std::nullopt` is the idiomatic return value for an empty `std::optional`. `has_value()` is the explicit check, `if (!result)` is the concise form.
 - `getStream()` cannot be `const` because using a stream modifies internal state — cursor advances, error flags can change.
 - Accepting `std::ios::openmode` directly instead of a mode string eliminates branching entirely. No string comparison, no magic strings, compiler catches invalid modes.

--- a/docs/daily_logs/2026-04-09.md
+++ b/docs/daily_logs/2026-04-09.md
@@ -20,7 +20,7 @@
 - `std::string&` cannot bind to a string literal (rvalue). Use `const std::string&` or pass by value.
 - CSV loading requires a second constructor that accepts UUID as a parameter. Regenerating UUIDs on load would break referential integrity with policies and interactions.
 - `std::nullopt` is the idiomatic return value for an empty `std::optional`. `has_value()` is the explicit check, `if (!result)` is the concise form.
-- `getStream()` cannot be `const` because using a stream modifies internal state — cursor advances, error flags can change.
+- `getStream()` cannot be `const` because using a stream modifies internal state, cursor advances, error flags can change.
 - Accepting `std::ios::openmode` directly instead of a mode string eliminates branching entirely. No string comparison, no magic strings, compiler catches invalid modes.
 
 **Architecture reasoning:**
@@ -45,7 +45,7 @@ virtual std::optional<Client> findByUuid(const std::string& uuid) const = 0;
 virtual std::optional<Client> findByEmail(const std::string& email) const = 0;
 ```
 
-**Decision — in-memory storage:**
+**Decision: in-memory storage**
 
 Version 1 uses `std::vector<Client>`. O(n) search is acceptable for the current dataset size. Evaluating `std::unordered_map` as a secondary index for future improvement: O(1) lookup for `findByEmail` and `findByUuid` at the cost of index maintenance on every mutation. Will document as a formal ADR when implementing `ClientService`.
 

--- a/docs/daily_logs/2026-04-10.md
+++ b/docs/daily_logs/2026-04-10.md
@@ -1,0 +1,47 @@
+**April 10, 2026**
+
+**Active branch:** feature/3-client-crud
+**Issue:** #3
+
+**What I built:**
+- `serialize()` and `deserialize()` private helpers in `CsvClientRepository`
+- Full field mapping between `Client` object and CSV line in both directions
+- All CRUD methods in `CsvClientRepository`: `insertClient`, `removeClient`, `updateClient`, `findByUuid`, `findByEmail`, `findAll`
+- `load()` and `save()` with atomic write pattern using `.tmp` file and `std::rename`
+- Fixed `removeClient` to set `dirty_` only when something was actually removed using captured iterator from `remove_if`
+- Fixed trailing comma in `serialize`
+- Handled missing file in `load` with `std::filesystem::exists` check — starts with empty dataset on first run
+- Refactored `Client` optional fields from `std::string` to `std::optional<std::string>`
+- Replaced `static` helper functions in `client.cpp` with anonymous namespace
+- Added loading constructor to `Client` accepting all fields including uuid, status, timestamps
+- Created `ClientData` DTO struct in domain layer for transferring input data to the service
+- Started `ClientService` header with constructor and method signatures
+
+**What I learned:**
+- Anonymous namespace is the idiomatic modern C++ replacement for `static` on free functions.
+- `remove_if` returns an iterator to the first garbage element — check against `clients_.end()` before erasing and setting `dirty_`.
+- Return by value is the safe default. Return `const&` only when exposing something with a guaranteed lifetime tied to the owning object.
+- `std::optional` cannot hold references. `const std::optional<std::string>&` is a reference to an optional — valid and safe. `std::optional<std::string&>` is a reference inside an optional — forbidden.
+- Setters accept `std::string` by value, not `std::optional` — setters provide values, they do not express absence.
+- `std::move` on an enum is redundant — enums are trivially copyable integers with no heap resource to steal.
+- `const std::string&` is idiomatic for any string parameter you only need to read, including search terms passed as temporaries.
+- DTO pattern groups related input fields under a meaningful name, prevents argument order errors, and keeps signatures stable when fields are added.
+- `ClientData` lives in the domain layer — it is input data for domain operations, not a presentation or data concern.
+
+**Architecture reasoning:**
+
+`updateClient` design went through two rejected approaches before landing on the correct one. `findByUuid` cannot be reused for in-place replacement because it returns a copy. Passing old and new objects adds no information the repository needs. Final design: one parameter, UUID extracted from the updated object, `find_if` used internally to get a mutable iterator.
+
+Constructor validation in `Client` kept as defensive safety net even when the service validates first. The loading constructor skips validation — data loaded from CSV was already validated at creation time.
+
+`ClientService` receives `IClientRepository&` by injection from the composition root. It never instantiates the repository. UUID is the internal key — users interact only with human-readable fields. The CLI resolves name searches to UUIDs before passing them to service operations.
+
+**Open items:**
+- Enum serialization: `statusToString` and `stringToStatus` helpers
+- Notes field: getter, setter, serialization
+- Field ordering in CSV: status and notes before timestamps
+- `ClientService` implementation: `addClient`, `deleteClient`, `editClient`, `searchClients`
+- Serialize/deserialize must stay in sync after optional field changes
+
+**Next session:**
+Implement `ClientService` methods. Start with `addClient` — email uniqueness check, construct `Client` from `ClientData`, call `insertClient`. Then `searchClients`, `deleteClient`, `editClient`.

--- a/docs/daily_logs/2026-04-10.md
+++ b/docs/daily_logs/2026-04-10.md
@@ -19,22 +19,22 @@
 
 **What I learned:**
 - Anonymous namespace is the idiomatic modern C++ replacement for `static` on free functions.
-- `remove_if` returns an iterator to the first garbage element — check against `clients_.end()` before erasing and setting `dirty_`.
+- `remove_if` returns an iterator to the first garbage element, check against `clients_.end()` before erasing and setting `dirty_`.
 - Return by value is the safe default. Return `const&` only when exposing something with a guaranteed lifetime tied to the owning object.
-- `std::optional` cannot hold references. `const std::optional<std::string>&` is a reference to an optional — valid and safe. `std::optional<std::string&>` is a reference inside an optional — forbidden.
-- Setters accept `std::string` by value, not `std::optional` — setters provide values, they do not express absence.
-- `std::move` on an enum is redundant — enums are trivially copyable integers with no heap resource to steal.
+- `std::optional` cannot hold references. `const std::optional<std::string>&` is a reference to an optional, valid and safe. `std::optional<std::string&>` is a reference inside an optional forbidden.
+- Setters accept `std::string` by value, not `std::optional` setters provide values, they do not express absence.
+- `std::move` on an enum is redundant. Enums are trivially copyable integers with no heap resource to steal.
 - `const std::string&` is idiomatic for any string parameter you only need to read, including search terms passed as temporaries.
 - DTO pattern groups related input fields under a meaningful name, prevents argument order errors, and keeps signatures stable when fields are added.
-- `ClientData` lives in the domain layer — it is input data for domain operations, not a presentation or data concern.
+- `ClientData` lives in the domain layer it is input data for domain operations, not a presentation or data concern.
 
 **Architecture reasoning:**
 
 `updateClient` design went through two rejected approaches before landing on the correct one. `findByUuid` cannot be reused for in-place replacement because it returns a copy. Passing old and new objects adds no information the repository needs. Final design: one parameter, UUID extracted from the updated object, `find_if` used internally to get a mutable iterator.
 
-Constructor validation in `Client` kept as defensive safety net even when the service validates first. The loading constructor skips validation — data loaded from CSV was already validated at creation time.
+Constructor validation in `Client` kept as defensive safety net even when the service validates first. The loading constructor skips validation data loaded from CSV was already validated at creation time.
 
-`ClientService` receives `IClientRepository&` by injection from the composition root. It never instantiates the repository. UUID is the internal key — users interact only with human-readable fields. The CLI resolves name searches to UUIDs before passing them to service operations.
+`ClientService` receives `IClientRepository&` by injection from the composition root. It never instantiates the repository. UUID is the internal key users interact only with human-readable fields. The CLI resolves name searches to UUIDs before passing them to service operations.
 
 **Open items:**
 - Enum serialization: `statusToString` and `stringToStatus` helpers
@@ -44,4 +44,4 @@ Constructor validation in `Client` kept as defensive safety net even when the se
 - Serialize/deserialize must stay in sync after optional field changes
 
 **Next session:**
-Implement `ClientService` methods. Start with `addClient` — email uniqueness check, construct `Client` from `ClientData`, call `insertClient`. Then `searchClients`, `deleteClient`, `editClient`.
+Implement `ClientService` methods. Start with `addClient` email uniqueness check, construct `Client` from `ClientData`, call `insertClient`. Then `searchClients`, `deleteClient`, `editClient`.

--- a/docs/daily_logs/2026-04-11.md
+++ b/docs/daily_logs/2026-04-11.md
@@ -1,0 +1,49 @@
+**April 11, 2026**
+
+**Active branch:** feature/3-client-crud
+**Issue:** #3
+
+**What I built:**
+- `ClientService` header with constructor, reference member initialization via initializer list, and method signatures for `addClient`, `deleteClient`, `editClient`, `searchClients`
+- `ClientData` DTO struct with required and optional fields, `lead_status` defaulting to `NEW`
+- Complete `ClientService` implementation: `addClient`, `deleteClient`, `editClient`, `searchClients`, `isEmailUnique`
+- Status refactor across all layers: `ClientData.lead_status` changed to `std::optional<Client::ClientStatus>`, type-safe throughout, string conversion only at CSV boundaries
+- `statusToString` and `statusFromString` helpers in dedicated `client_status.hpp/cpp` in domain layer
+- Fixed logic inversion in `isEmailUnique`, now correctly returns `true` when email is not found
+- `ClientView` in `src/cli/client_view.hpp` and `src/cli/client_view.cpp` with two static methods: `displayAll` for table output and `displayOne` for key-value detail view. Thinking and design were mine, execution partially delegated to AI since it was mechanical formatting work with no new concepts.
+- Updated `src/cli/CMakeLists.txt` with `target_include_directories` to expose cli headers consistently with other layers.
+
+**What I learned:**
+- Reference members must be initialized in the member initializer list, not the constructor body. A reference cannot be default-initialized or reseated after binding, it must refer to something from the moment the object exists.
+- Member initializer list constructs members directly. Constructor body runs after members are already constructed, so for references only the initializer list works.
+- Abstract classes can be used as the type for references and parameters. The concrete type is instantiated once at the composition root and injected. Every layer above sees only the interface.
+- `std::optional` overloads `*` and `->` operators mirroring pointer syntax. `*client` and `client.value()` are equivalent when the optional is known to have a value. `client.value()` throws `std::bad_optional_access` if empty, `*client` is undefined behavior if empty. Use either after an explicit existence check.
+- `findByUuid` returns by value intentionally for `editClient`. The copy is the mechanism: fetch copy, modify via setters, pass to `updateClient`. The vector element is replaced with the modified copy.
+- `find` on `std::string` returns `std::string::npos` if the substring is not found, the same sentinel pattern as iterator-based searches returning `end()`.
+- An empty result from a search is not an exceptional condition, return an empty vector and let the caller decide how to present it.
+- String conversion should happen only at system boundaries, CSV serialization and user input. Domain objects work with typed enums throughout.
+- `value_or` on optional provides a clean default without branching, `client_data.lead_status.value_or(ClientStatus::NEW)` expresses intent directly.
+- Anonymous namespace scope is limited to one translation unit. When helpers are needed across multiple files, a dedicated header is the correct scope.
+- `std::setw` and `std::left` are stream manipulators, same mechanism as everything else used with streams. No new concept, just formatting syntax.
+- UUID intentionally omitted from `displayOne`, it is an internal key not meaningful to the user. What storage needs and what the user sees are different representations of the same data.
+- `insura_domain` exposes `src/domain` as a PUBLIC include directory, so targets linking it can include domain headers by filename only without path prefix.
+- Static methods on a view class are appropriate when the presenter carries no state, it only transforms data into output.
+
+**Architecture reasoning:**
+
+Status type consistency enforced across all layers eliminates implicit string-to-enum conversions scattered through the codebase. The DTO carries the typed enum, the service receives it typed, the constructor stores it typed. Only `serialize` and `deserialize` touch strings at the exact boundary where strings are necessary.
+
+`editClient` pattern is complete: fetch copy, guard nullopt, apply only provided fields via setters, pass modified copy to repository. Fields not present in the DTO retain their current values.
+
+`ClientView` depends only on `insura_domain`, no coupling to service or data layers. It receives data and displays it, never fetches, never modifies. Presentation layer is a one-way boundary: data flows in, output flows out.
+
+`isEmailUnique` is a private helper, only `addClient` calls it now but it will also be needed when email editing is added to `editClient` later. Correct placement as private on the service.
+
+**Open questions:**
+- Required fields editability: first_name, last_name, email, decision pending. Email change needs uniqueness check routed through service.
+- Notes field: replace, append, or edit in place.
+- Custom domain error types considered but deferred.
+- Exception handling strategy to be studied more deeply.
+
+**Next session:**
+Implement `Application` class with main loop, menu display, dispatch commands to service, catch exceptions at the boundary. Then `main.cpp` composition root. Then end-to-end smoke test.

--- a/docs/daily_logs/2026-04-13.md
+++ b/docs/daily_logs/2026-04-13.md
@@ -1,0 +1,52 @@
+**April 13, 2026**
+
+**Active branch:** feature/3-client-crud
+**Issue:** #3
+
+**What I built:**
+- Architecture recap and verification of understanding across all layers
+- `Application` header with constructor, `run()`, private command methods, dispatch table as `std::unordered_map<std::string, std::function<void()>>`, `initCommands()` private helper
+- `Application` constructor and `initCommands()` implementation, dispatch table populated with lambdas capturing `this`
+- `main.cpp` composition root with startup menu, filepath prompting, repo construction with `unique_ptr`, conditional `load()` call with retry loop, dependency injection into service and application
+- `cmdAdd` with full validation, re-prompt loops for required and validated optional fields, helper functions in anonymous namespace
+- `cmdSave`, one line calling `repo_.save()` through the interface
+- `cmdList`, one line calling `repo_.findAll()` and passing to `ClientView::displayAll`
+- Default filepath constant `kDefaultFilepath` in `main.cpp` for the "start empty" after failed load case
+- Added `explicit` keyword to `CSVClientRepository`, `ClientService`, and `FileHandler` constructors
+- Fixed `generateUuid` name mismatch between `utils.hpp` and `utils.cpp`
+- Removed `cmdStartup()` from `Application`, startup flow moved entirely to `main.cpp`
+
+**What I learned:**
+- `explicit` prevents the compiler from using a single-argument constructor for implicit type conversions. Only single-argument constructors are affected because the compiler cannot produce two values from one.
+- `std::function<void()>` is a type-erased callable wrapper. The signature inside must match the stored callables exactly. `void()` means takes nothing, returns nothing.
+- Dispatch table pattern: `std::unordered_map<std::string, std::function<void()>>` maps command strings to handler lambdas capturing `this`. Adding a command means adding one map entry.
+- `std::unique_ptr` owns a heap-allocated object, destroyed automatically when out of scope. `make_unique<T>(args...)` is the safe construction form. Dereferencing with `*ptr` gives a reference to the owned object.
+- `unique_ptr` used in `main.cpp` because `repo` must be declared before the if/else block but cannot be default-constructed without a filepath.
+- `load()` removed from the constructor, separating construction from loading gives `main.cpp` full control over the startup flow.
+- `save()` belongs in `IClientRepository` as a pure virtual method. `load()` does not, it is CSV-specific with filepath and file existence concerns.
+- `private override` on `CSVClientRepository::save()` is still callable through a base reference. Access control is checked at the call site against the static type, the vtable resolves the correct implementation at runtime regardless.
+- `std::move` on validated temporaries before assigning to `ClientData` fields avoids unnecessary copies. After the move the temporary is in a valid but unspecified state, acceptable since it is not used again.
+
+**Architecture reasoning:**
+
+Validation exists in two layers intentionally, not as duplication. Domain layer validation protects `Client` object invariants regardless of who constructs it, a future test harness, REST handler, or batch importer bypasses the CLI entirely. CLI layer validation is pure UX, re-prompt immediately, surface clear messages, never reach the service with bad data. Each copy serves a different master. Removing either breaks something real.
+
+Email uniqueness cannot be checked proactively by the CLI because it requires a repo call. `cmdAdd` wraps `client_service_.addClient` in a try/catch and surfaces the duplicate-email exception. This is correct, uniqueness is a business rule, not a format rule.
+
+`cmdList` calls `repo_.findAll()` directly rather than adding a `listClients` wrapper on `ClientService`. A service wrapper with no added logic is indirection with no value.
+
+`main.cpp` is the only place that knows about `CsvClientRepository` as a concrete type. It handles startup, filepath prompting, file existence, and calls `load()` directly. Everything above receives `IClientRepository&`.
+
+Default filepath `kDefaultFilepath` lives in `main.cpp` because configuration is a startup concern. The natural evolution is reading it from a config file, zero changes to any other layer when that happens.
+
+**Open items:**
+- `Application::run()` not yet implemented
+- `cmdSearch`, `cmdEdit`, `cmdDelete` not yet implemented
+- End-to-end smoke test pending
+- Phone standardisation deferred to polish milestone
+- ADR-009: date format decision pending
+- ADR-013: config file to replace hardcoded default filepath
+- Notes getter and setter still missing from `Client`
+
+**Next session:**
+Implement `Application::run()`, then `cmdSearch` with the search/select pattern, then `cmdEdit` and `cmdDelete`. Then end-to-end smoke test to close issue #3.

--- a/src/cli/CMakeLists.txt
+++ b/src/cli/CMakeLists.txt
@@ -6,6 +6,11 @@ PRIVATE
   insura_service
 )
 
+target_include_directories(insura_cli
+  PUBLIC
+    ${CMAKE_CURRENT_SOURCE_DIR}
+)
+
 target_sources(insura_cli
 PRIVATE
   menu.cpp

--- a/src/cli/application.cpp
+++ b/src/cli/application.cpp
@@ -1,0 +1,330 @@
+#include "application.hpp"
+
+#include <iostream>
+#include <regex>
+
+#include "client_service.hpp"
+#include "client_view.hpp"
+
+/*
+ * Note before starting: I won't care about the menu and options
+ * I will improve them using AI or understanding how to
+ * write better descriptions but for now I want to be fast and
+ * focus on the main work.
+ */
+
+namespace {
+
+/* CLI-layer format validators: kept here for immediate re-prompt UX.
+ * Domain-layer checks in client.cpp remain the authoritative last line of
+ * defence and must not be removed. */
+
+bool isValidEmail(const std::string& email) {
+  const std::regex pattern("(\\w+)(\\.|_)?(\\w*)@(\\w+)(\\.(\\w+))+");
+  return std::regex_match(email, pattern);
+}
+
+bool isDigitsOnly(const std::string& str) {
+  return !str.empty() &&
+         std::find_if(str.begin(), str.end(), [](unsigned char c) {
+           return !std::isdigit(c);
+         }) == str.end();
+}
+
+bool isValidPhone(const std::string& phone) {
+  /* TODO: standardise phone display: add country-code prefix (e.g. +39)
+   * and decide whether to keep phone as std::string or introduce a dedicated
+   * type/format. Handle at end-of-project cleanup. */
+  return isDigitsOnly(phone);
+}
+
+std::string promptRequired(const std::string& label) {
+  std::string value;
+  do {
+    std::cout << label;
+    std::getline(std::cin, value);
+    if (value.empty()) std::cout << "  This field is required.\n";
+  } while (value.empty());
+  return value;
+}
+
+std::optional<std::string> promptOptional(const std::string& label) {
+  std::string value;
+  std::cout << label;
+  std::getline(std::cin, value);
+  if (value.empty()) return std::nullopt;
+  return value;
+}
+
+}  // namespace
+
+namespace insura::cli {
+
+Application::Application(service::ClientService& client_service,
+                         domain::IClientRepository& repo)
+    : client_service_(client_service), repo_(repo) {
+  initCommands();
+}
+
+void Application::initCommands() {
+  commands_["add"] = [this]() { cmdAdd(); };
+  commands_["list"] = [this]() { cmdList(); };
+  commands_["search"] = [this]() { cmdSearch(); };
+  commands_["edit"] = [this]() { cmdEdit(); };
+  commands_["delete"] = [this]() { cmdDelete(); };
+  commands_["save"] = [this]() { cmdSave(); };
+  commands_["exit"] = [this]() { cmdExit(); };
+}
+
+void Application::cmdAdd() {
+  domain::ClientData data;
+
+  /* TODO: this could be better handled using iomanip */
+  std::cout << "--- Add New Client ---\n";
+
+  /* Required fields */
+  data.first_name = promptRequired("First name: ");
+  data.last_name = promptRequired("Last name: ");
+
+  while (true) {
+    std::cout << "Email: ";
+    std::string email;
+    std::getline(std::cin, email);
+    if (email.empty()) {
+      std::cout << "  This field is required.\n";
+      continue;
+    }
+    if (!isValidEmail(email)) {
+      std::cout << "  Invalid email format.\n";
+      continue;
+    }
+    data.email = std::move(email);
+    break;
+  }
+
+  /* Optional fields */
+  while (true) {
+    auto phone = promptOptional("Phone (optional, digits only): ");
+    if (!phone.has_value()) break;
+    if (!isValidPhone(*phone)) {
+      std::cout << "  Phone must contain digits only.\n";
+      continue;
+    }
+    data.phone = std::move(phone);
+    break;
+  }
+
+  data.job_title = promptOptional("Job title (optional): ");
+  data.company = promptOptional("Company (optional): ");
+  data.address = promptOptional("Address (optional): ");
+  data.city = promptOptional("City (optional): ");
+
+  while (true) {
+    auto postal_code = promptOptional("Postal code (optional, digits only): ");
+    if (!postal_code.has_value()) break;
+    if (!isDigitsOnly(*postal_code)) {
+      std::cout << "  Postal code must contain digits only.\n";
+      continue;
+    }
+    data.postal_code = std::move(postal_code);
+    break;
+  }
+
+  data.notes = promptOptional("Notes (optional): ");
+
+  try {
+    client_service_.addClient(data);
+    std::cout << "Client added successfully.\n";
+  } catch (const std::invalid_argument& e) {
+    std::cout << "  Error: " << e.what() << "\n";
+  }
+}
+
+insura::domain::Client Application::selectClient(
+    const std::vector<insura::domain::Client>& clients) {
+  for (std::size_t i = 0; i < clients.size(); ++i) {
+    std::cout << "  [" << (i + 1) << "] " << clients[i].getFirstName() << " "
+              << clients[i].getLastName() << " — " << clients[i].getEmail()
+              << '\n';
+  }
+
+  while (true) {
+    std::cout << "Select a client (1-" << clients.size() << "): ";
+    std::string input;
+    std::getline(std::cin, input);
+    if (!isDigitsOnly(input)) {
+      std::cout << "  Please enter a valid number.\n";
+      continue;
+    }
+    int index = std::stoi(input);
+    if (index < 1 || index > static_cast<int>(clients.size())) {
+      std::cout << "  Number out of range.\n";
+      continue;
+    }
+    return clients[static_cast<std::size_t>(index - 1)];
+  }
+}
+
+std::optional<domain::Client> Application::resolveClient() {
+  std::string term;
+  do {
+    std::cout << "Search: ";
+    std::getline(std::cin, term);
+
+    /* TODO: I should decide if when the search term is leaved empty
+     * I have to ask the user if he wants to exit or re-prompting.
+     * I don't know if it is necessary since if the user select the
+     * option, probably he wants to search something but maybe
+     * it select the wrong option for a typing error */
+    if (term.empty()) continue;
+
+    std::vector<domain::Client> found = client_service_.searchClients(term);
+
+    if (found.empty()) {
+      std::cout << "No Contact Found\n";
+
+    } else if (found.size() == 1) {
+      return found.at(0);
+
+    } else {
+      domain::Client selected = selectClient(found);
+      return selected;
+    }
+
+  } while (term.empty());
+
+  return std::nullopt;
+}
+
+void Application::cmdSearch() {
+  auto client = resolveClient();
+  if (client) ClientView::displayOne(*client);
+}
+
+domain::ClientData Application::promptEditData(const domain::Client& current) {
+  domain::ClientData updated_data;
+
+  /* Required fields — shown with current value; leave blank to keep */
+  std::optional<std::string> first =
+      promptOptional("First name [" + current.getFirstName() + "]: ");
+  if (first) updated_data.first_name = std::move(*first);
+
+  std::optional<std::string> last =
+      promptOptional("Last name [" + current.getLastName() + "]: ");
+  if (last) updated_data.last_name = std::move(*last);
+
+  while (true) {
+    std::optional<std::string> email =
+        promptOptional("Email [" + current.getEmail() + "]: ");
+    if (!email)
+      break;
+    else if (!isValidEmail(*email)) {
+      std::cout << "  Invalid email format.\n";
+      continue;
+    } else {
+      updated_data.email = std::move(*email);
+      break;
+    }
+  }
+
+  while (true) {
+    std::string prompt = current.getPhone()
+                             ? "Phone [" + current.getPhone().value() + "]: "
+                             : "Phone (optional): ";
+
+    auto phone = promptOptional(prompt);
+    if (!phone.has_value()) break;
+
+    if (!isValidPhone(*phone)) {
+      std::cout << "  Phone must contain digits only.\n";
+      continue;
+    }
+    updated_data.phone = std::move(phone);
+    break;
+  }
+
+  {
+    std::string prompt =
+        current.getJobTitle()
+            ? "Job title [" + current.getJobTitle().value() + "]: "
+            : "Job title (optional): ";
+    updated_data.job_title = promptOptional(prompt);
+  }
+
+  {
+    std::string prompt =
+        current.getCompany()
+            ? "Company [" + current.getCompany().value() + "]: "
+            : "Company (optional): ";
+    updated_data.company = promptOptional(prompt);
+  }
+
+  {
+    std::string prompt =
+        current.getAddress()
+            ? "Address [" + current.getAddress().value() + "]: "
+            : "Address (optional): ";
+    updated_data.address = promptOptional(prompt);
+  }
+
+  {
+    std::string prompt = current.getCity()
+                             ? "City [" + current.getCity().value() + "]: "
+                             : "City (optional): ";
+    updated_data.city = promptOptional(prompt);
+  }
+
+  while (true) {
+    std::string prompt =
+        current.getPostalCode()
+            ? "Postal code [" + current.getPostalCode().value() + "]: "
+            : "Postal code (optional, digits only): ";
+    auto postal_code = promptOptional(prompt);
+    if (!postal_code.has_value()) break;
+    if (!isDigitsOnly(*postal_code)) {
+      std::cout << "  Postal code must contain digits only.\n";
+      continue;
+    }
+    updated_data.postal_code = std::move(postal_code);
+    break;
+  }
+
+  {
+    std::string prompt = current.getNotes()
+                             ? "Notes [" + current.getNotes().value() + "]: "
+                             : "Notes (optional): ";
+    updated_data.notes = promptOptional(prompt);
+  }
+
+  return updated_data;
+}
+
+void Application::cmdList() { ClientView::displayAll(repo_.findAll()); }
+
+void Application::cmdDelete() {
+  auto client = resolveClient();
+  if (!client) return;
+
+  try {
+    client_service_.deleteClient(client->getUuid());
+  } catch (const std::invalid_argument& e) {
+    std::cout << " Error: " << e.what() << "\n";
+  }
+}
+
+void Application::cmdEdit() {
+  auto client = resolveClient();
+  if (!client) return;
+
+  domain::ClientData updated = promptEditData(*client);
+  try {
+    client_service_.editClient(client->getUuid(), updated);
+    std::cout << "Client updated successfully.\n";
+  } catch (const std::invalid_argument& e) {
+    std::cout << "  Error: " << e.what() << "\n";
+  }
+}
+
+void Application::cmdSave() { repo_.save(); }
+
+}  // namespace insura::cli

--- a/src/cli/application.cpp
+++ b/src/cli/application.cpp
@@ -69,13 +69,22 @@ Application::Application(service::ClientService& client_service,
 
 void Application::initCommands() {
   commands_["add"] = [this]() { cmdAdd(); };
-  commands_["list"] = [this]() { cmdList(); };
   commands_["search"] = [this]() { cmdSearch(); };
+  commands_["list"] = [this]() { cmdList(); };
+  commands_["view"] = [this]() { cmdView(); };
   commands_["edit"] = [this]() { cmdEdit(); };
   commands_["delete"] = [this]() { cmdDelete(); };
+  commands_["config"] = [this]() { cmdConfig(); };
   commands_["save"] = [this]() { cmdSave(); };
+  commands_["clear"] = [this]() { cmdClear(); };
   commands_["exit"] = [this]() { cmdExit(); };
 }
+
+void Application::cmdView() { std::cout << "Feature not implemented yet!"; }
+
+void Application::cmdConfig() { std::cout << "Feature not implemented yet!"; }
+
+void Application::cmdClear() { std::cout << "Feature not implemented yet!"; }
 
 void Application::cmdAdd() {
   domain::ClientData data;
@@ -130,6 +139,9 @@ void Application::cmdAdd() {
     data.postal_code = std::move(postal_code);
     break;
   }
+
+  /* TODO: I should add an helper function for status that list
+   * options and the user can select the status */
 
   data.notes = promptOptional("Notes (optional): ");
 
@@ -335,10 +347,10 @@ void Application::cmdExit() {
 
 void Application::run() {
   running_ = true;
-  Menu::display();
 
   while (running_) {
     std::string option;
+    Menu::display();
     std::cout << "> ";
     std::getline(std::cin, option);
 

--- a/src/cli/application.cpp
+++ b/src/cli/application.cpp
@@ -5,6 +5,7 @@
 
 #include "client_service.hpp"
 #include "client_view.hpp"
+#include "menu.hpp"
 
 /*
  * Note before starting: I won't care about the menu and options
@@ -326,5 +327,28 @@ void Application::cmdEdit() {
 }
 
 void Application::cmdSave() { repo_.save(); }
+
+void Application::cmdExit() {
+  std::cout << "Closing session.\n";
+  running_ = false;
+}
+
+void Application::run() {
+  running_ = true;
+  Menu::display();
+
+  while (running_) {
+    std::string option;
+    std::cout << "> ";
+    std::getline(std::cin, option);
+
+    auto it = commands_.find(option);
+    if (it != commands_.end()) {
+      it->second();
+    } else {
+      std::cout << "  Unknown command. Type a command from the menu above.\n";
+    }
+  }
+}
 
 }  // namespace insura::cli

--- a/src/cli/application.hpp
+++ b/src/cli/application.hpp
@@ -1,0 +1,35 @@
+#pragma once
+#include <functional>
+#include <unordered_map>
+
+#include "../domain/i_client_repository.hpp"
+#include "../service/client_service.hpp"
+
+namespace insura::cli {
+
+class Application {
+ public:
+  Application(service::ClientService& client_service,
+              domain::IClientRepository& repo);
+  void run();
+
+ private:
+  service::ClientService& client_service_;
+  domain::IClientRepository& repo_;
+  std::unordered_map<std::string, std::function<void()>> commands_;
+  void initCommands();
+  domain::Client selectClient(const std::vector<domain::Client>& clients);
+  std::optional<domain::Client> resolveClient();
+  domain::ClientData promptEditData(const domain::Client& current);
+
+  /* Commands */
+  void cmdAdd();
+  void cmdList();
+  void cmdSearch();
+  void cmdEdit();
+  void cmdDelete();
+  void cmdSave();
+  void cmdExit();
+};
+
+}  // namespace insura::cli

--- a/src/cli/application.hpp
+++ b/src/cli/application.hpp
@@ -14,9 +14,12 @@ class Application {
   void run();
 
  private:
+  bool running_ = false;
   service::ClientService& client_service_;
   domain::IClientRepository& repo_;
   std::unordered_map<std::string, std::function<void()>> commands_;
+
+  /* Helpers */
   void initCommands();
   domain::Client selectClient(const std::vector<domain::Client>& clients);
   std::optional<domain::Client> resolveClient();

--- a/src/cli/application.hpp
+++ b/src/cli/application.hpp
@@ -29,10 +29,13 @@ class Application {
   void cmdAdd();
   void cmdList();
   void cmdSearch();
+  void cmdView();
   void cmdEdit();
   void cmdDelete();
+  void cmdConfig();
   void cmdSave();
   void cmdExit();
+  void cmdClear();
 };
 
 }  // namespace insura::cli

--- a/src/cli/client_view.cpp
+++ b/src/cli/client_view.cpp
@@ -15,6 +15,7 @@ const std::string kSeparator(kColWidth * 5, '-');
 
 /* TODO: understand which informations are the most useful to display, for now
  * it's ok to leave those */
+
 void ClientView::displayAll(const std::vector<domain::Client>& clients) {
   std::cout << std::left << std::setw(kColWidth) << "FIRST NAME"
             << std::setw(kColWidth) << "LAST NAME" << std::setw(kColWidth)

--- a/src/cli/client_view.cpp
+++ b/src/cli/client_view.cpp
@@ -1,0 +1,53 @@
+#include "client_view.hpp"
+
+#include <iomanip>
+#include <iostream>
+#include <string>
+
+#include "client_status.hpp"
+
+namespace insura::cli {
+
+namespace {
+constexpr int kColWidth = 22;
+const std::string kSeparator(kColWidth * 5, '-');
+}  // namespace
+
+/* TODO: understand which informations are the most useful to display, for now
+ * it's ok to leave those */
+void ClientView::displayAll(const std::vector<domain::Client>& clients) {
+  std::cout << std::left << std::setw(kColWidth) << "FIRST NAME"
+            << std::setw(kColWidth) << "LAST NAME" << std::setw(kColWidth)
+            << "EMAIL" << std::setw(kColWidth) << "LEAD STATUS"
+            << std::setw(kColWidth) << "CREATED AT" << '\n'
+            << kSeparator << '\n';
+
+  for (const auto& c : clients) {
+    std::cout << std::left << std::setw(kColWidth) << c.getFirstName()
+              << std::setw(kColWidth) << c.getLastName() << std::setw(kColWidth)
+              << c.getEmail() << std::setw(kColWidth)
+              << domain::statusToString(c.getStatus()) << std::setw(kColWidth)
+              << c.getCreatedAt() << '\n';
+  }
+}
+
+void ClientView::displayOne(const domain::Client& c) {
+  auto opt = [](const std::optional<std::string>& v) -> std::string {
+    return v.has_value() ? v.value() : "N/A";
+  };
+
+  std::cout << "First name:  " << c.getFirstName() << '\n'
+            << "Last name:   " << c.getLastName() << '\n'
+            << "Email:       " << c.getEmail() << '\n'
+            << "Phone:       " << opt(c.getPhone()) << '\n'
+            << "Job title:   " << opt(c.getJobTitle()) << '\n'
+            << "Company:     " << opt(c.getCompany()) << '\n'
+            << "Address:     " << opt(c.getAddress()) << '\n'
+            << "City:        " << opt(c.getCity()) << '\n'
+            << "Postal code: " << opt(c.getPostalCode()) << '\n'
+            << "Lead status: " << domain::statusToString(c.getStatus()) << '\n'
+            << "Created at:  " << c.getCreatedAt() << '\n'
+            << "Updated at:  " << c.getUpdatedAt() << '\n';
+}
+
+}  // namespace insura::cli

--- a/src/cli/client_view.hpp
+++ b/src/cli/client_view.hpp
@@ -1,0 +1,14 @@
+#pragma once
+#include <vector>
+
+#include "client.hpp"
+
+namespace insura::cli {
+
+class ClientView {
+ public:
+  static void displayAll(const std::vector<domain::Client>& clients);
+  static void displayOne(const domain::Client& client);
+};
+
+}  // namespace insura::cli

--- a/src/cli/menu.cpp
+++ b/src/cli/menu.cpp
@@ -1,0 +1,30 @@
+#include "menu.hpp"
+
+#include <iomanip>
+#include <iostream>
+#include <string>
+
+namespace insura::cli {
+
+namespace {
+constexpr int kCmdWidth = 10;
+const std::string kSeparator(kCmdWidth + 30, '-');
+}  // namespace
+
+void Menu::display() {
+  std::cout << "\nInsuraPro CRM\n"
+            << kSeparator << '\n'
+            << std::left << std::setw(kCmdWidth) << "add"    << "— add a new client\n"
+            << std::setw(kCmdWidth) << "search" << "— search clients\n"
+            << std::setw(kCmdWidth) << "list"   << "— list all clients\n"
+            << std::setw(kCmdWidth) << "view"   << "— view a client's full record\n"
+            << std::setw(kCmdWidth) << "edit"   << "— edit a client\n"
+            << std::setw(kCmdWidth) << "delete" << "— delete a client\n"
+            << std::setw(kCmdWidth) << "save"   << "— save data to CSV\n"
+            << std::setw(kCmdWidth) << "config" << "— view or edit application configuration\n"
+            << std::setw(kCmdWidth) << "clear"  << "— clear the terminal screen\n"
+            << std::setw(kCmdWidth) << "exit"   << "— exit\n"
+            << kSeparator << '\n';
+}
+
+}  // namespace insura::cli

--- a/src/cli/menu.cpp
+++ b/src/cli/menu.cpp
@@ -14,16 +14,20 @@ const std::string kSeparator(kCmdWidth + 30, '-');
 void Menu::display() {
   std::cout << "\nInsuraPro CRM\n"
             << kSeparator << '\n'
-            << std::left << std::setw(kCmdWidth) << "add"    << "— add a new client\n"
+            << std::left << std::setw(kCmdWidth) << "add"
+            << "— add a new client\n"
             << std::setw(kCmdWidth) << "search" << "— search clients\n"
-            << std::setw(kCmdWidth) << "list"   << "— list all clients\n"
-            << std::setw(kCmdWidth) << "view"   << "— view a client's full record\n"
-            << std::setw(kCmdWidth) << "edit"   << "— edit a client\n"
+            << std::setw(kCmdWidth) << "list" << "— list all clients\n"
+            << std::setw(kCmdWidth) << "view"
+            << "— view a client's full record\n"
+            << std::setw(kCmdWidth) << "edit" << "— edit a client\n"
             << std::setw(kCmdWidth) << "delete" << "— delete a client\n"
-            << std::setw(kCmdWidth) << "save"   << "— save data to CSV\n"
-            << std::setw(kCmdWidth) << "config" << "— view or edit application configuration\n"
-            << std::setw(kCmdWidth) << "clear"  << "— clear the terminal screen\n"
-            << std::setw(kCmdWidth) << "exit"   << "— exit\n"
+            << std::setw(kCmdWidth) << "save" << "— save data to CSV\n"
+            << std::setw(kCmdWidth) << "config"
+            << "— view or edit application configuration\n"
+            << std::setw(kCmdWidth) << "clear"
+            << "— clear the terminal screen\n"
+            << std::setw(kCmdWidth) << "exit" << "— exit\n"
             << kSeparator << '\n';
 }
 

--- a/src/cli/menu.hpp
+++ b/src/cli/menu.hpp
@@ -1,0 +1,10 @@
+#pragma once
+
+namespace insura::cli {
+
+class Menu {
+ public:
+  static void display();
+};
+
+}  // namespace insura::cli

--- a/src/data/csv_client_repository.cpp
+++ b/src/data/csv_client_repository.cpp
@@ -103,12 +103,12 @@ std::string CSVClientRepository::serialize(const domain::Client& c) const {
   ss << c.getLastName() << ",";
   ss << c.getEmail() << ",";
 
-  ss << c.getPhone() << ",";
-  ss << c.getJobTitle() << ",";
-  ss << c.getCompany() << ",";
-  ss << c.getAddress() << ",";
-  ss << c.getCity() << ",";
-  ss << c.getPostalCode() << ",";
+  ss << c.getPhone().value_or("") << ",";
+  ss << c.getJobTitle().value_or("") << ",";
+  ss << c.getCompany().value_or("") << ",";
+  ss << c.getAddress().value_or("") << ",";
+  ss << c.getCity().value_or("") << ",";
+  ss << c.getPostalCode().value_or("") << ",";
   ss << ",";  // status placeholder
   ss << ",";  // notes placeholder
   ss << c.getCreatedAt() << ",";

--- a/src/data/csv_client_repository.cpp
+++ b/src/data/csv_client_repository.cpp
@@ -1,0 +1,157 @@
+#include "csv_client_repository.hpp"
+
+#include <filesystem>
+#include <optional>
+#include <sstream>
+#include <string>
+
+#include "file_handle.hpp"
+
+/* TODO: I have to remember to do defensive checks for operations
+ *
+ * But I think is not its responsibility?
+ * I am not sure becasue the dirty flag is updated here and since it must be
+ * updated only if operation succeed, I should make some checks.
+ *
+ * */
+
+namespace insura::data {
+
+void CSVClientRepository::insertClient(const domain::Client& client) {
+  clients_.push_back(client);
+  dirty_ = true;
+}
+void CSVClientRepository::removeClient(const std::string& uuid) {
+  auto it = std::remove_if(clients_.begin(), clients_.end(),
+                           [&uuid](const domain::Client& client) {
+                             return client.getUuid() == uuid;
+                           });
+  if (it != clients_.end()) {
+    clients_.erase(it, clients_.end());
+    dirty_ = true;
+  }
+}
+
+std::optional<domain::Client> CSVClientRepository::findByUuid(
+    const std::string& uuid) const {
+  auto it = std::find_if(
+      clients_.begin(), clients_.end(),
+      [&uuid](const domain::Client& c) { return c.getUuid() == uuid; });
+
+  if (it == clients_.end()) return std::nullopt;
+  return *it;
+}
+
+std::optional<domain::Client> CSVClientRepository::findByEmail(
+    const std::string& email) const {
+  auto it = std::find_if(
+      clients_.begin(), clients_.end(),
+      [&email](const domain::Client& c) { return c.getEmail() == email; });
+
+  if (it == clients_.end()) return std::nullopt;
+  return *it;
+}
+
+const std::vector<domain::Client>& CSVClientRepository::findAll() const {
+  return clients_;
+}
+
+void CSVClientRepository::updateClient(const domain::Client& updated) {
+  auto it = std::find_if(clients_.begin(), clients_.end(),
+                         [&updated](const domain::Client& c) {
+                           return c.getUuid() == updated.getUuid();
+                         });
+
+  if (it != clients_.end()) {
+    *it = updated;
+    dirty_ = true;
+  }
+}
+
+void CSVClientRepository::load() {
+  std::vector<domain::Client> tmp_clients;
+
+  if (std::filesystem::exists(filepath_)) {
+    {
+      FileHandler in(filepath_, std::ios::in);
+      std::string line;
+
+      while (std::getline(in.getStream(), line)) {
+        tmp_clients.push_back(deserialize(line));
+      }
+    }
+  };
+
+  clients_ = std::move(tmp_clients);
+}
+
+void CSVClientRepository::save() const {
+  std::string tmp = filepath_ + ".tmp";
+  {
+    FileHandler out(tmp, std::ios::out);
+    for (const auto& c : clients_) {
+      out.getStream() << serialize(c) << "\n";
+    }
+  }
+  std::rename(tmp.c_str(), filepath_.c_str());  // atomic swap
+}
+
+std::string CSVClientRepository::serialize(const domain::Client& c) const {
+  std::ostringstream ss;
+  ss << c.getUuid() << ",";
+  ss << c.getFirstName() << ",";
+  ss << c.getLastName() << ",";
+  ss << c.getEmail() << ",";
+
+  ss << c.getPhone() << ",";
+  ss << c.getJobTitle() << ",";
+  ss << c.getCompany() << ",";
+  ss << c.getAddress() << ",";
+  ss << c.getCity() << ",";
+  ss << c.getPostalCode() << ",";
+  ss << ",";  // status placeholder
+  ss << ",";  // notes placeholder
+  ss << c.getCreatedAt() << ",";
+  ss << c.getUpdatedAt();
+
+  /* TODO:
+   * - I should create an helper function to convert the
+   *   status from enum into a string and viceversa
+   * - handle notes (with getter and setter and decide how to
+   *   proper use them inside those functions)
+   * - Put both field before created at and updated at
+   */
+
+  return ss.str();
+}
+
+domain::Client CSVClientRepository::deserialize(const std::string& line) const {
+  std::stringstream ss(line);
+  std::string uuid, first, last, email, phone, job, company, address, city,
+      postal_code, status, notes, created_at, updated_at;
+
+  std::getline(ss, uuid, ',');
+  std::getline(ss, first, ',');
+  std::getline(ss, last, ',');
+  std::getline(ss, email, ',');
+  std::getline(ss, phone, ',');
+  std::getline(ss, job, ',');
+  std::getline(ss, company, ',');
+  std::getline(ss, address, ',');
+  std::getline(ss, city, ',');
+  std::getline(ss, postal_code, ',');
+
+  /* TODO: handle status and notes and ensure the correct order:
+   * 1. status, 2. notes */
+
+  std::getline(ss, status, ',');
+  std::getline(ss, notes, ',');
+  std::getline(ss, created_at, ',');
+  std::getline(ss, updated_at, ',');
+
+  return domain::Client(uuid, first, last, email, phone, job, company, address,
+                        city, postal_code, status, notes, created_at,
+                        updated_at);
+}
+
+}  // namespace insura::data

--- a/src/data/csv_client_repository.cpp
+++ b/src/data/csv_client_repository.cpp
@@ -3,6 +3,7 @@
 #include <filesystem>
 #include <optional>
 #include <sstream>
+#include <stdexcept>
 #include <string>
 
 #include "../domain/client_status.hpp"
@@ -19,9 +20,7 @@
 namespace insura::data {
 
 CSVClientRepository::CSVClientRepository(const std::string& filepath)
-    : filepath_(filepath) {
-  load();
-}
+    : filepath_(filepath) {}
 
 void CSVClientRepository::insertClient(const domain::Client& client) {
   clients_.push_back(client);
@@ -87,6 +86,8 @@ void CSVClientRepository::load() {
         tmp_clients.push_back(deserialize(line));
       }
     }
+  } else {
+    throw std::runtime_error("Error: File doesn't exist");
   };
 
   clients_ = std::move(tmp_clients);

--- a/src/data/csv_client_repository.cpp
+++ b/src/data/csv_client_repository.cpp
@@ -18,6 +18,11 @@
 
 namespace insura::data {
 
+CSVClientRepository::CSVClientRepository(const std::string& filepath)
+    : filepath_(filepath) {
+  load();
+}
+
 void CSVClientRepository::insertClient(const domain::Client& client) {
   clients_.push_back(client);
   dirty_ = true;
@@ -112,8 +117,8 @@ std::string CSVClientRepository::serialize(const domain::Client& c) const {
   ss << c.getCity().value_or("") << ",";
   ss << c.getPostalCode().value_or("") << ",";
 
-  ss << domain::statusToString(c.getStatus()) << ",";  
-  ss << ",";                                           // notes placeholder
+  ss << domain::statusToString(c.getStatus()) << ",";
+  ss << "" << ",";  // notes placeholder
   ss << c.getCreatedAt() << ",";
   ss << c.getUpdatedAt();
 

--- a/src/data/csv_client_repository.cpp
+++ b/src/data/csv_client_repository.cpp
@@ -5,6 +5,7 @@
 #include <sstream>
 #include <string>
 
+#include "../domain/client_status.hpp"
 #include "file_handle.hpp"
 
 /* TODO: I have to remember to do defensive checks for operations
@@ -21,6 +22,7 @@ void CSVClientRepository::insertClient(const domain::Client& client) {
   clients_.push_back(client);
   dirty_ = true;
 }
+
 void CSVClientRepository::removeClient(const std::string& uuid) {
   auto it = std::remove_if(clients_.begin(), clients_.end(),
                            [&uuid](const domain::Client& client) {
@@ -109,18 +111,11 @@ std::string CSVClientRepository::serialize(const domain::Client& c) const {
   ss << c.getAddress().value_or("") << ",";
   ss << c.getCity().value_or("") << ",";
   ss << c.getPostalCode().value_or("") << ",";
-  ss << ",";  // status placeholder
-  ss << ",";  // notes placeholder
+
+  ss << domain::statusToString(c.getStatus()) << ",";  
+  ss << ",";                                           // notes placeholder
   ss << c.getCreatedAt() << ",";
   ss << c.getUpdatedAt();
-
-  /* TODO:
-   * - I should create an helper function to convert the
-   *   status from enum into a string and viceversa
-   * - handle notes (with getter and setter and decide how to
-   *   proper use them inside those functions)
-   * - Put both field before created at and updated at
-   */
 
   return ss.str();
 }
@@ -149,8 +144,10 @@ domain::Client CSVClientRepository::deserialize(const std::string& line) const {
   std::getline(ss, created_at, ',');
   std::getline(ss, updated_at, ',');
 
+  domain::Client::ClientStatus lead_status = domain::statusFromString(status);
+
   return domain::Client(uuid, first, last, email, phone, job, company, address,
-                        city, postal_code, status, notes, created_at,
+                        city, postal_code, lead_status, notes, created_at,
                         updated_at);
 }
 

--- a/src/data/csv_client_repository.hpp
+++ b/src/data/csv_client_repository.hpp
@@ -1,0 +1,27 @@
+#include "../domain/client.hpp"
+#include "../domain/i_client_repository.hpp"
+
+namespace insura::data {
+
+class CSVClientRepository : public domain::IClientRepository {
+ public:
+  void insertClient(const domain::Client& client) override;
+  void removeClient(const std::string& uuid) override;
+  void updateClient(const domain::Client& updated) override;
+  std::optional<domain::Client> findByUuid(
+      const std::string& uuid) const override;
+  std::optional<domain::Client> findByEmail(
+      const std::string& email) const override;
+  const std::vector<domain::Client>& findAll() const override;
+
+ private:
+  void load();
+  void save() const;
+  std::string serialize(const domain::Client& c) const;
+  domain::Client deserialize(const std::string& line) const;
+  std::vector<domain::Client> clients_;
+  std::string filepath_;
+  bool dirty_ = false;
+  ;
+};
+}  // namespace insura::data

--- a/src/data/csv_client_repository.hpp
+++ b/src/data/csv_client_repository.hpp
@@ -1,3 +1,4 @@
+#pragma once
 #include "../domain/client.hpp"
 #include "../domain/i_client_repository.hpp"
 

--- a/src/data/csv_client_repository.hpp
+++ b/src/data/csv_client_repository.hpp
@@ -6,6 +6,7 @@ namespace insura::data {
 
 class CSVClientRepository : public domain::IClientRepository {
  public:
+  explicit CSVClientRepository(const std::string& filepath);
   void insertClient(const domain::Client& client) override;
   void removeClient(const std::string& uuid) override;
   void updateClient(const domain::Client& updated) override;

--- a/src/data/csv_client_repository.hpp
+++ b/src/data/csv_client_repository.hpp
@@ -7,6 +7,7 @@ namespace insura::data {
 class CSVClientRepository : public domain::IClientRepository {
  public:
   explicit CSVClientRepository(const std::string& filepath);
+  void load();
   void insertClient(const domain::Client& client) override;
   void removeClient(const std::string& uuid) override;
   void updateClient(const domain::Client& updated) override;
@@ -17,8 +18,7 @@ class CSVClientRepository : public domain::IClientRepository {
   const std::vector<domain::Client>& findAll() const override;
 
  private:
-  void load();
-  void save() const;
+  void save() const override;
   std::string serialize(const domain::Client& c) const;
   domain::Client deserialize(const std::string& line) const;
   std::vector<domain::Client> clients_;

--- a/src/data/file_handle.cpp
+++ b/src/data/file_handle.cpp
@@ -1,0 +1,19 @@
+#include "file_handle.hpp"
+
+#include <iostream>
+
+namespace insura::data {
+
+FileHandler::FileHandler(std::string filepath, std::ios::openmode mode) {
+  std::fstream file(filepath, mode);
+
+  if (!file.is_open()) {
+    throw std::runtime_error("Error: Unable to open file!\n");
+  }
+
+  file_ = std::move(file);
+}
+
+FileHandler::~FileHandler() { file_.close(); }
+
+}  // namespace insura::data

--- a/src/data/file_handle.cpp
+++ b/src/data/file_handle.cpp
@@ -14,6 +14,8 @@ FileHandler::FileHandler(std::string filepath, std::ios::openmode mode) {
   file_ = std::move(file);
 }
 
+std::fstream& FileHandler::getStream() { return file_; }
+
 FileHandler::~FileHandler() { file_.close(); }
 
 }  // namespace insura::data

--- a/src/data/file_handle.hpp
+++ b/src/data/file_handle.hpp
@@ -4,7 +4,7 @@
 namespace insura::data {
 class FileHandler {
  public:
-  FileHandler(std::string filepath, std::ios::openmode mode);
+  explicit FileHandler(std::string filepath, std::ios::openmode mode);
   ~FileHandler();
   std::fstream& getStream();
 

--- a/src/data/file_handle.hpp
+++ b/src/data/file_handle.hpp
@@ -1,11 +1,12 @@
-#include <string>
 #include <fstream>
+#include <string>
 
 namespace insura::data {
 class FileHandler {
  public:
   FileHandler(std::string filepath, std::ios::openmode mode);
   ~FileHandler();
+  std::fstream& getStream();
 
  private:
   std::fstream file_;

--- a/src/data/file_handle.hpp
+++ b/src/data/file_handle.hpp
@@ -1,0 +1,14 @@
+#include <string>
+#include <fstream>
+
+namespace insura::data {
+class FileHandler {
+ public:
+  FileHandler(std::string filepath, std::ios::openmode mode);
+  ~FileHandler();
+
+ private:
+  std::fstream file_;
+};
+
+}  // namespace insura::data

--- a/src/domain/CMakeLists.txt
+++ b/src/domain/CMakeLists.txt
@@ -6,6 +6,7 @@ target_sources(insura_domain
     policy.cpp
     interaction.cpp
     utils.cpp
+    client_status.cpp
 )
 
 target_include_directories(insura_domain

--- a/src/domain/CMakeLists.txt
+++ b/src/domain/CMakeLists.txt
@@ -5,6 +5,7 @@ target_sources(insura_domain
     client.cpp
     policy.cpp
     interaction.cpp
+    uuid.cpp
 )
 
 target_include_directories(insura_domain

--- a/src/domain/CMakeLists.txt
+++ b/src/domain/CMakeLists.txt
@@ -5,7 +5,7 @@ target_sources(insura_domain
     client.cpp
     policy.cpp
     interaction.cpp
-    uuid.cpp
+    utils.cpp
 )
 
 target_include_directories(insura_domain

--- a/src/domain/client.cpp
+++ b/src/domain/client.cpp
@@ -1,7 +1,9 @@
 #include "client.hpp"
 
+#include <cctype>
 #include <ctime>
 #include <regex>
+#include <stdexcept>
 
 #include "utils.hpp"
 
@@ -35,17 +37,35 @@
  *
  */
 
+/* TODO: update this function to be more restrictive */
 static bool isValidEmail(const std::string& email) {
   const std::regex pattern("(\\w+)(\\.|_)?(\\w*)@(\\w+)(\\.(\\w+))+");
 
   return std::regex_match(email, pattern);
 }
 
+static bool isNumber(const std::string& str) {
+  /* Function explanation:
+   *  - AND condition: is true if both are true
+   *  - first check: the string is not empty, if empty the function returns
+   *    true immediately
+   *  - then usee the function find if to ensure all elements are digit
+   *    - find if returns an iterator to the first element for which the
+   *    function returns true
+   *    - since I've setted it to return false, if the postal code is correct
+   *    it should return the last element that is str.end()
+   *    - if the postal code is wrong, it will return something that is not a
+   *    digit and the final check will be false */
+  return !str.empty() &&
+         std::find_if(str.begin(), str.end(), [](unsigned char c) {
+           return !std::isdigit(c);
+         }) == str.end();
+}
+
 namespace insura::domain {
 
 Client::Client(std::string first_name, std::string last_name,
                std::string email) {
-
   if (first_name.empty()) {
     throw std::invalid_argument("first name cannot be empty");
   }
@@ -67,11 +87,69 @@ Client::Client(std::string first_name, std::string last_name,
   last_name_ = std::move(last_name);
   email_ = std::move(email);
   created_at_ = utils::currentTimestamp();
-  lead_status_ = LeadStatus::NEW;
+  lead_status_ = ClientStatus::NEW;
 }
 
+const std::string& Client::getUuid() const {return uuid_;}
 const std::string& Client::getFirstName() const { return first_name_; }
 const std::string& Client::getLastName() const { return last_name_; }
 const std::string& Client::getEmail() const { return email_; }
+const std::string& Client::getPhone() const { return phone_; }
+const std::string& Client::getAddress() const { return address_; }
+const std::string& Client::getCity() const { return city_; }
+const std::string& Client::getPostalCode() const { return postal_code_; }
+const std::string& Client::getJobTitle() const { return job_title_; }
+const std::string& Client::getCompany() const { return company_; }
+Client::ClientStatus Client::getStatus() const { return lead_status_; }
+const std::string& Client::getUpdatedAt() const { return updated_at_; }
+const std::string& Client::createdAt() const { return created_at_; }
+
+// TODO: add the notes getter/setter
+
+/* TODO: here I should add validation for each field but for now I will maintain
+ * things simple */
+void Client::setPhone(const std::string phone) {
+  /* simple validation: check if all char are numbers
+   * TODO: add validation based on format like +39... and standardise
+   * format especially in the display */
+  if (!isNumber(phone)) throw std::invalid_argument("invalid phone number");
+
+  phone_ = std::move(phone);
+  updated_at_ = utils::currentTimestamp();
+}
+void Client::setAddress(const std::string address) {
+  address_ = std::move(address);
+  updated_at_ = utils::currentTimestamp();
+}
+void Client::setCity(const std::string city) {
+  city_ = std::move(city);
+  updated_at_ = utils::currentTimestamp();
+}
+void Client::setPostalCode(const std::string postal_code) {
+  if (!isNumber(postal_code))
+    throw std::invalid_argument("invalid postal code");
+
+  postal_code_ = std::move(postal_code);
+  updated_at_ = utils::currentTimestamp();
+}
+
+/* TODO: evaluate to make the job title an enum or something like that
+ * and choose between fixed alternatives in order to create a standardized
+ * way to represents jobs
+ *
+ * Same for companies, choose a fixed pre-set of companies */
+void Client::setJobTitle(const std::string job_title) {
+  job_title_ = std::move(job_title);
+  updated_at_ = utils::currentTimestamp();
+}
+void Client::setCompany(const std::string company) {
+  company_ = std::move(company);
+  updated_at_ = utils::currentTimestamp();
+}
+
+void Client::setStatus(ClientStatus status) {
+  lead_status_ = status;
+  updated_at_ = utils::currentTimestamp();
+}
 
 }  // namespace insura::domain

--- a/src/domain/client.cpp
+++ b/src/domain/client.cpp
@@ -1,0 +1,77 @@
+#include "client.hpp"
+
+#include <ctime>
+#include <regex>
+
+#include "utils.hpp"
+
+/*
+ * Reasoning behind design: I don't want to use exceptions in
+ * each part of my code, I want to balance defensive checks and
+ * exceptions handling.
+ *
+ * I mean, I've studied the principle according to which if you
+ * expect something, don't use exception. Use them only for things
+ * that you don't expect
+ *
+ * At the same time, I don't know in C++ if this is valid since
+ * I've studied it for Python but in Python is easier to manage
+ * empty inputs or something like that, in C++ you should handle
+ * memory, pointers and stuff like that.
+ *
+ * This is what I think about exceptions (I will ignore the
+ * distinction I've made above):
+ * You should handle exceptions differently depending on the layer
+ * you are in:
+ * - E.g. error during program startup (e.g. setup): terminate
+ *   the program early
+ * - error during the main operations (user layer): status code
+ * - error during mid-operations (e.g. adding a client): handle
+ *   it and ensure atomicity
+ *
+ * Then I have to do the following
+ * - understand if the regex could be improved
+ * - why std::move for copying attributes
+ *
+ */
+
+static bool isValidEmail(const std::string& email) {
+  const std::regex pattern("(\\w+)(\\.|_)?(\\w*)@(\\w+)(\\.(\\w+))+");
+
+  return std::regex_match(email, pattern);
+}
+
+namespace insura::domain {
+
+Client::Client(std::string first_name, std::string last_name,
+               std::string email) {
+
+  if (first_name.empty()) {
+    throw std::invalid_argument("first name cannot be empty");
+  }
+
+  if (last_name.empty()) {
+    throw std::invalid_argument("last name cannot be empty");
+  }
+
+  if (email.empty()) {
+    throw std::invalid_argument("email cannot be empty");
+  }
+
+  if (!isValidEmail(email)) {
+    throw std::invalid_argument("invalid email");
+  }
+
+  uuid_ = utils::generateUuid();
+  first_name_ = std::move(first_name);
+  last_name_ = std::move(last_name);
+  email_ = std::move(email);
+  created_at_ = utils::currentTimestamp();
+  lead_status_ = LeadStatus::NEW;
+}
+
+const std::string& Client::getFirstName() const { return first_name_; }
+const std::string& Client::getLastName() const { return last_name_; }
+const std::string& Client::getEmail() const { return email_; }
+
+}  // namespace insura::domain

--- a/src/domain/client.cpp
+++ b/src/domain/client.cpp
@@ -38,13 +38,16 @@
  */
 
 /* TODO: update this function to be more restrictive */
-static bool isValidEmail(const std::string& email) {
+
+namespace {
+
+bool isValidEmail(const std::string& email) {
   const std::regex pattern("(\\w+)(\\.|_)?(\\w*)@(\\w+)(\\.(\\w+))+");
 
   return std::regex_match(email, pattern);
 }
 
-static bool isNumber(const std::string& str) {
+bool isNumber(const std::string& str) {
   /* Function explanation:
    *  - AND condition: is true if both are true
    *  - first check: the string is not empty, if empty the function returns
@@ -61,11 +64,18 @@ static bool isNumber(const std::string& str) {
            return !std::isdigit(c);
          }) == str.end();
 }
+}  // namespace
 
 namespace insura::domain {
 
-Client::Client(std::string first_name, std::string last_name,
-               std::string email) {
+Client::Client(std::string first_name, std::string last_name, std::string email,
+               std::optional<std::string> phone,
+               std::optional<std::string> job_title,
+               std::optional<std::string> company,
+               std::optional<std::string> address,
+               std::optional<std::string> city,
+               std::optional<std::string> postal_code,
+               std::optional<std::string> notes) {
   if (first_name.empty()) {
     throw std::invalid_argument("first name cannot be empty");
   }
@@ -86,29 +96,70 @@ Client::Client(std::string first_name, std::string last_name,
   first_name_ = std::move(first_name);
   last_name_ = std::move(last_name);
   email_ = std::move(email);
+  phone_ = std::move(phone);
+  job_title_ = std::move(job_title);
+  company_ = std::move(company);
+  address_ = std::move(address);
+  city_ = std::move(city);
+  postal_code_ = std::move(postal_code);
+
   created_at_ = utils::currentTimestamp();
   lead_status_ = ClientStatus::NEW;
 }
 
-const std::string& Client::getUuid() const {return uuid_;}
+Client::Client(std::string uuid, std::string first_name, std::string last_name,
+               std::string email, std::optional<std::string> phone,
+               std::optional<std::string> job_title,
+               std::optional<std::string> company,
+               std::optional<std::string> address,
+               std::optional<std::string> city,
+               std::optional<std::string> postal_code, ClientStatus status,
+               std::optional<std::string> notes, std::string created_at,
+               std::string updated_at) {
+  uuid_ = std::move(uuid);
+  first_name_ = std::move(first_name);
+  last_name_ = std::move(last_name);
+  email_ = std::move(email);
+  phone_ = std::move(phone);
+  job_title_ = std::move(job_title);
+  company_ = std::move(company);
+  address_ = std::move(address);
+  city_ = std::move(city);
+  postal_code_ = std::move(postal_code);
+
+  lead_status_ = status;
+  notes_ = std::move(notes);
+  created_at_ = std::move(created_at);
+  updated_at_ = std::move(updated_at);
+}
+
+const std::string& Client::getUuid() const { return uuid_; }
 const std::string& Client::getFirstName() const { return first_name_; }
 const std::string& Client::getLastName() const { return last_name_; }
 const std::string& Client::getEmail() const { return email_; }
-const std::string& Client::getPhone() const { return phone_; }
-const std::string& Client::getAddress() const { return address_; }
-const std::string& Client::getCity() const { return city_; }
-const std::string& Client::getPostalCode() const { return postal_code_; }
-const std::string& Client::getJobTitle() const { return job_title_; }
-const std::string& Client::getCompany() const { return company_; }
+const std::optional<std::string>& Client::getPhone() const { return phone_; }
+const std::optional<std::string>& Client::getAddress() const {
+  return address_;
+}
+const std::optional<std::string>& Client::getCity() const { return city_; }
+const std::optional<std::string>& Client::getPostalCode() const {
+  return postal_code_;
+}
+const std::optional<std::string>& Client::getJobTitle() const {
+  return job_title_;
+}
+const std::optional<std::string>& Client::getCompany() const {
+  return company_;
+}
 Client::ClientStatus Client::getStatus() const { return lead_status_; }
 const std::string& Client::getUpdatedAt() const { return updated_at_; }
-const std::string& Client::createdAt() const { return created_at_; }
+const std::string& Client::getCreatedAt() const { return created_at_; }
 
 // TODO: add the notes getter/setter
 
 /* TODO: here I should add validation for each field but for now I will maintain
  * things simple */
-void Client::setPhone(const std::string phone) {
+void Client::setPhone(std::string phone) {
   /* simple validation: check if all char are numbers
    * TODO: add validation based on format like +39... and standardise
    * format especially in the display */
@@ -117,15 +168,15 @@ void Client::setPhone(const std::string phone) {
   phone_ = std::move(phone);
   updated_at_ = utils::currentTimestamp();
 }
-void Client::setAddress(const std::string address) {
+void Client::setAddress(std::string address) {
   address_ = std::move(address);
   updated_at_ = utils::currentTimestamp();
 }
-void Client::setCity(const std::string city) {
+void Client::setCity(std::string city) {
   city_ = std::move(city);
   updated_at_ = utils::currentTimestamp();
 }
-void Client::setPostalCode(const std::string postal_code) {
+void Client::setPostalCode(std::string postal_code) {
   if (!isNumber(postal_code))
     throw std::invalid_argument("invalid postal code");
 
@@ -138,11 +189,11 @@ void Client::setPostalCode(const std::string postal_code) {
  * way to represents jobs
  *
  * Same for companies, choose a fixed pre-set of companies */
-void Client::setJobTitle(const std::string job_title) {
+void Client::setJobTitle(std::string job_title) {
   job_title_ = std::move(job_title);
   updated_at_ = utils::currentTimestamp();
 }
-void Client::setCompany(const std::string company) {
+void Client::setCompany(std::string company) {
   company_ = std::move(company);
   updated_at_ = utils::currentTimestamp();
 }

--- a/src/domain/client.cpp
+++ b/src/domain/client.cpp
@@ -156,7 +156,33 @@ Client::ClientStatus Client::getStatus() const { return lead_status_; }
 const std::string& Client::getUpdatedAt() const { return updated_at_; }
 const std::string& Client::getCreatedAt() const { return created_at_; }
 
-// TODO: add the notes getter/setter
+const std::optional<std::string>& Client::getNotes() const { return notes_; }
+
+void Client::setFirstName(std::string first_name) {
+  if (first_name.empty())
+    throw std::invalid_argument("first name cannot be empty");
+  first_name_ = std::move(first_name);
+  updated_at_ = utils::currentTimestamp();
+}
+
+void Client::setLastName(std::string last_name) {
+  if (last_name.empty())
+    throw std::invalid_argument("last name cannot be empty");
+  last_name_ = std::move(last_name);
+  updated_at_ = utils::currentTimestamp();
+}
+
+void Client::setEmail(std::string email) {
+  if (email.empty()) throw std::invalid_argument("email cannot be empty");
+  if (!isValidEmail(email)) throw std::invalid_argument("invalid email");
+  email_ = std::move(email);
+  updated_at_ = utils::currentTimestamp();
+}
+
+void Client::setNotes(std::string notes) {
+  notes_ = std::move(notes);
+  updated_at_ = utils::currentTimestamp();
+}
 
 /* TODO: here I should add validation for each field but for now I will maintain
  * things simple */

--- a/src/domain/client.cpp
+++ b/src/domain/client.cpp
@@ -64,6 +64,7 @@ bool isNumber(const std::string& str) {
            return !std::isdigit(c);
          }) == str.end();
 }
+
 }  // namespace
 
 namespace insura::domain {
@@ -74,7 +75,7 @@ Client::Client(std::string first_name, std::string last_name, std::string email,
                std::optional<std::string> company,
                std::optional<std::string> address,
                std::optional<std::string> city,
-               std::optional<std::string> postal_code,
+               std::optional<std::string> postal_code, ClientStatus status,
                std::optional<std::string> notes) {
   if (first_name.empty()) {
     throw std::invalid_argument("first name cannot be empty");
@@ -102,9 +103,9 @@ Client::Client(std::string first_name, std::string last_name, std::string email,
   address_ = std::move(address);
   city_ = std::move(city);
   postal_code_ = std::move(postal_code);
-
+  lead_status_ = status;
+  notes_ = std::move(notes);
   created_at_ = utils::currentTimestamp();
-  lead_status_ = ClientStatus::NEW;
 }
 
 Client::Client(std::string uuid, std::string first_name, std::string last_name,

--- a/src/domain/client.hpp
+++ b/src/domain/client.hpp
@@ -48,6 +48,9 @@ class Client {
   const std::string& getUpdatedAt() const;
   const std::string& getCreatedAt() const;
 
+  void setFirstName(std::string first_name);
+  void setLastName(std::string last_name);
+  void setEmail(std::string email);
   void setPhone(std::string phone);
   void setJobTitle(std::string job_title);
   void setCompany(std::string company);
@@ -55,6 +58,7 @@ class Client {
   void setCity(std::string city);
   void setPostalCode(std::string postal_code);
   void setStatus(ClientStatus status);
+  void setNotes(std::string notes);
 
   const std::optional<std::string>& getPhone() const;
   const std::optional<std::string>& getJobTitle() const;
@@ -62,10 +66,8 @@ class Client {
   const std::optional<std::string>& getAddress() const;
   const std::optional<std::string>& getCity() const;
   const std::optional<std::string>& getPostalCode() const;
+  const std::optional<std::string>& getNotes() const;
   ClientStatus getStatus() const;
-
-  /* TODO: understand how to add note field: I mean, the simplest form is
-   * to write and press enter but maybe I want some specialized behaviours */
 
  private:
   /* evaluate to add birthay date since CRM may wants to know in order to

--- a/src/domain/client.hpp
+++ b/src/domain/client.hpp
@@ -1,4 +1,5 @@
 #pragma once
+#include <optional>
 #include <string>
 
 /*
@@ -23,30 +24,44 @@ class Client {
     CLOSED_LOST,
   };
 
-  Client(std::string first_name, std::string last_name, std::string email);
+  Client(std::string first_name, std::string last_name, std::string email,
+         std::optional<std::string> phone, std::optional<std::string> job_title,
+         std::optional<std::string> company, std::optional<std::string> address,
+         std::optional<std::string> city,
+         std::optional<std::string> postal_code,
+         std::optional<std::string> notes);
+
+  // Loading constructor
+  Client(std::string uuid, std::string first_name, std::string last_name,
+         std::string email, std::optional<std::string> phone,
+         std::optional<std::string> job_title,
+         std::optional<std::string> company, std::optional<std::string> address,
+         std::optional<std::string> city,
+         std::optional<std::string> postal_code, ClientStatus status,
+         std::optional<std::string> notes, std::string created_at,
+         std::string updated_at);
 
   const std::string& getUuid() const;
   const std::string& getEmail() const;
   const std::string& getFirstName() const;
   const std::string& getLastName() const;
   const std::string& getUpdatedAt() const;
-  const std::string& createdAt() const;
+  const std::string& getCreatedAt() const;
 
-
-  void setPhone(const std::string phone);
-  void setAddress(const std::string address);
-  void setCity(const std::string city);
-  void setPostalCode(const std::string postal_code);
-  void setJobTitle(const std::string job_title);
-  void setCompany(const std::string company);
+  void setPhone(std::string phone);
+  void setJobTitle(std::string job_title);
+  void setCompany(std::string company);
+  void setAddress(std::string address);
+  void setCity(std::string city);
+  void setPostalCode(std::string postal_code);
   void setStatus(ClientStatus status);
 
-  const std::string& getPhone() const;
-  const std::string& getAddress() const;
-  const std::string& getCity() const;
-  const std::string& getPostalCode() const;
-  const std::string& getJobTitle() const;
-  const std::string& getCompany() const;
+  const std::optional<std::string>& getPhone() const;
+  const std::optional<std::string>& getJobTitle() const;
+  const std::optional<std::string>& getCompany() const;
+  const std::optional<std::string>& getAddress() const;
+  const std::optional<std::string>& getCity() const;
+  const std::optional<std::string>& getPostalCode() const;
   ClientStatus getStatus() const;
 
   /* TODO: understand how to add note field: I mean, the simplest form is
@@ -60,14 +75,14 @@ class Client {
   std::string first_name_;
   std::string last_name_;
   std::string email_;
-  std::string phone_;
-  std::string address_;
-  std::string city_;
-  std::string postal_code_;
-  std::string job_title_;
-  std::string company_;
-  std::string notes_;
+  std::optional<std::string> phone_;
+  std::optional<std::string> job_title_;
+  std::optional<std::string> company_;
+  std::optional<std::string> address_;
+  std::optional<std::string> city_;
+  std::optional<std::string> postal_code_;
   ClientStatus lead_status_;
+  std::optional<std::string> notes_;
   std::string created_at_;
   std::string updated_at_;
 };

--- a/src/domain/client.hpp
+++ b/src/domain/client.hpp
@@ -28,7 +28,7 @@ class Client {
          std::optional<std::string> phone, std::optional<std::string> job_title,
          std::optional<std::string> company, std::optional<std::string> address,
          std::optional<std::string> city,
-         std::optional<std::string> postal_code,
+         std::optional<std::string> postal_code, ClientStatus status,
          std::optional<std::string> notes);
 
   // Loading constructor

--- a/src/domain/client.hpp
+++ b/src/domain/client.hpp
@@ -13,7 +13,7 @@ namespace insura::domain {
 
 class Client {
  public:
-  enum class LeadStatus {
+  enum class ClientStatus {
     NEW,
     CONTACTED,
     IN_PROGRESS,
@@ -29,21 +29,33 @@ class Client {
   const std::string& getEmail() const;
   const std::string& getFirstName() const;
   const std::string& getLastName() const;
-  void setPhone(const std::string& phone);
+  const std::string& getUpdatedAt() const;
+  const std::string& createdAt() const;
 
-  // I don't know if it's better to use the same function to set all of 
-  // them since they are related
-  void setAddress(const std::string& address);
-  void setCity(const std::string& city);
-  void setPostalCode(const std::string& postal_code);
 
-  // the same is true for job title and company
-  void setJobTitle(const std::string& job_title);
+  void setPhone(const std::string phone);
+  void setAddress(const std::string address);
+  void setCity(const std::string city);
+  void setPostalCode(const std::string postal_code);
+  void setJobTitle(const std::string job_title);
+  void setCompany(const std::string company);
+  void setStatus(ClientStatus status);
 
-  // set status I think should be choice (number) so the user can't input
-  // invalid data
-  
+  const std::string& getPhone() const;
+  const std::string& getAddress() const;
+  const std::string& getCity() const;
+  const std::string& getPostalCode() const;
+  const std::string& getJobTitle() const;
+  const std::string& getCompany() const;
+  ClientStatus getStatus() const;
+
+  /* TODO: understand how to add note field: I mean, the simplest form is
+   * to write and press enter but maybe I want some specialized behaviours */
+
  private:
+  /* evaluate to add birthay date since CRM may wants to know in order to
+   * create custom offers for this special day in order to lead the customer
+   * make make another contract */
   std::string uuid_;
   std::string first_name_;
   std::string last_name_;
@@ -55,7 +67,7 @@ class Client {
   std::string job_title_;
   std::string company_;
   std::string notes_;
-  LeadStatus lead_status_;
+  ClientStatus lead_status_;
   std::string created_at_;
   std::string updated_at_;
 };

--- a/src/domain/client.hpp
+++ b/src/domain/client.hpp
@@ -30,8 +30,19 @@ class Client {
   const std::string& getFirstName() const;
   const std::string& getLastName() const;
   void setPhone(const std::string& phone);
-  // ... other accessors
 
+  // I don't know if it's better to use the same function to set all of 
+  // them since they are related
+  void setAddress(const std::string& address);
+  void setCity(const std::string& city);
+  void setPostalCode(const std::string& postal_code);
+
+  // the same is true for job title and company
+  void setJobTitle(const std::string& job_title);
+
+  // set status I think should be choice (number) so the user can't input
+  // invalid data
+  
  private:
   std::string uuid_;
   std::string first_name_;

--- a/src/domain/client_data.hpp
+++ b/src/domain/client_data.hpp
@@ -1,0 +1,25 @@
+#pragma once
+#include <optional>
+#include <string>
+
+#include "client.hpp"
+
+namespace insura::domain {
+
+struct ClientData {
+  std::string first_name;
+  std::string last_name;
+  std::string email;
+
+  std::optional<std::string> phone;
+  std::optional<std::string> job_title;
+  std::optional<std::string> company;
+  std::optional<std::string> address;
+  std::optional<std::string> city;
+  std::optional<std::string> postal_code;
+  std::optional<std::string> notes;
+
+  std::optional<Client::ClientStatus> lead_status;
+};
+
+}  // namespace insura::domain

--- a/src/domain/client_status.cpp
+++ b/src/domain/client_status.cpp
@@ -1,0 +1,46 @@
+
+#include "client_status.hpp"
+
+#include <stdexcept>
+#include <string>
+
+namespace insura::domain {
+
+std::string statusToString(insura::domain::Client::ClientStatus status) {
+  switch (status) {
+    case insura::domain::Client::ClientStatus::NEW:
+      return "new";
+    case insura::domain::Client::ClientStatus::CONTACTED:
+      return "contacted";
+    case insura::domain::Client::ClientStatus::IN_PROGRESS:
+      return "in_progress";
+    case insura::domain::Client::ClientStatus::OPEN_DEAL:
+      return "open_deal";
+    case insura::domain::Client::ClientStatus::ATTEMPTED_TO_CONTACT:
+      return "attempted_to_contact";
+    case insura::domain::Client::ClientStatus::CLOSED_LOST:
+      return "closed_lost";
+    case insura::domain::Client::ClientStatus::CLOSED_WON:
+      return "closed_won";
+  }
+}
+
+insura::domain::Client::ClientStatus statusFromString(const std::string& str) {
+  if (str == "new") return insura::domain::Client::ClientStatus::NEW;
+  if (str == "contacted")
+    return insura::domain::Client::ClientStatus::CONTACTED;
+  if (str == "in_progress")
+    return insura::domain::Client::ClientStatus::IN_PROGRESS;
+  if (str == "open_deal")
+    return insura::domain::Client::ClientStatus::OPEN_DEAL;
+  if (str == "attempted_to_contact")
+    return insura::domain::Client::ClientStatus::ATTEMPTED_TO_CONTACT;
+  if (str == "closed_lost")
+    return insura::domain::Client::ClientStatus::CLOSED_LOST;
+  if (str == "closed_won")
+    return insura::domain::Client::ClientStatus::CLOSED_WON;
+
+  throw std::invalid_argument("Error: Unknown client status: " + str);
+}
+
+}  // namespace insura::domain

--- a/src/domain/client_status.hpp
+++ b/src/domain/client_status.hpp
@@ -1,0 +1,11 @@
+#pragma once
+#include <string>
+
+#include "client.hpp"
+
+namespace insura::domain {
+
+std::string statusToString(Client::ClientStatus status);
+Client::ClientStatus statusFromString(const std::string& str);
+
+}  // namespace insura::domain

--- a/src/domain/i_client_repository.hpp
+++ b/src/domain/i_client_repository.hpp
@@ -70,6 +70,7 @@ namespace insura::domain {
 
 class IClientRepository {
  public:
+  virtual void save() const = 0;
   virtual void insertClient(const Client& client) = 0;
   virtual void removeClient(const std::string& uuid) = 0;
   virtual void updateClient(const Client& updated) = 0;

--- a/src/domain/i_client_repository.hpp
+++ b/src/domain/i_client_repository.hpp
@@ -7,7 +7,7 @@
 
 /*
  *
- * TODO: add those details about implementation in a note (decisions log or 
+ * TODO: add those details about implementation in a note (decisions log or
  * journal or something like that)
  *
  * IClientRepository — abstract interface for client data access.
@@ -72,10 +72,11 @@ class IClientRepository {
  public:
   virtual void insertClient(const Client& client) = 0;
   virtual void removeClient(const std::string& uuid) = 0;
-  virtual void updateClient(const std::string& uuid, const Client& updated) = 0;
-  virtual std::optional<Client> findByUuid(const std::string& client_uuid) = 0;
-  virtual std::optional<Client> findByEmail(const std::string& email) = 0;
-  virtual std::vector<Client> findAll() = 0;
+  virtual void updateClient(const Client& updated) = 0;
+  virtual std::optional<Client> findByUuid(
+      const std::string& client_uuid) const = 0;
+  virtual std::optional<Client> findByEmail(const std::string& email) const = 0;
+  virtual const std::vector<Client>& findAll() const = 0;
   virtual ~IClientRepository() = default;
 };
 

--- a/src/domain/utils.cpp
+++ b/src/domain/utils.cpp
@@ -1,7 +1,10 @@
+#include <chrono>
+#include <ctime>
+#include <iomanip>
 #include <random>
 #include <sstream>
 
-namespace insura::domain {
+namespace insura::domain::utils {
 
 /*
  * UUID v4 generator implemented from scratch using std::stringstream.
@@ -49,4 +52,15 @@ std::string generate_uuid4() {
   return ss.str();
 }
 
-}  // namespace insura::domain
+std::string currentTimestamp() {
+  auto now = std::chrono::system_clock::now();
+  time_t t = std::chrono::system_clock::to_time_t(now);
+
+  std::tm* tm = std::localtime(&t);
+  std::ostringstream ss;
+
+  ss << std::put_time(tm, "%Y-%m-%d %H:%M:%S");
+  return ss.str();
+};
+
+}  // namespace insura::domain::utils

--- a/src/domain/utils.cpp
+++ b/src/domain/utils.cpp
@@ -28,7 +28,7 @@ namespace insura::domain::utils {
  * I must revisit in Milestone 3 when the auto-save thread is introduced.
  *
  */
-std::string generate_uuid4() {
+std::string generateUuid() {
   static std::random_device rd;
   static std::mt19937 mt(rd());
   static std::uniform_int_distribution<> dist(0, 15);

--- a/src/domain/utils.hpp
+++ b/src/domain/utils.hpp
@@ -1,0 +1,6 @@
+#include <string>
+
+namespace insura::domain::utils {
+std::string generateUuid();
+std::string currentTimestamp();
+}

--- a/src/domain/uuid.cpp
+++ b/src/domain/uuid.cpp
@@ -1,0 +1,52 @@
+#include <random>
+#include <sstream>
+
+namespace insura::domain {
+
+/*
+ * UUID v4 generator implemented from scratch using std::stringstream.
+ *
+ * Preferred from scratch implementation in order to learn about uuid4
+ * generation and string stream.
+ *
+ * UUID v4 structure: xxxxxxxx-xxxx-4xxx-yxxx-xxxxxxxxxxxx
+ * where x is a random hex digit, 4 is fixed (version), and y is
+ * one of 8, 9, a, b (RFC 4122 variant).
+ *
+ * std::hex tells the stream to format integers as hexadecimal, so
+ * writing the integer 10 produces "a" rather than "10".
+ *
+ * Static variables are initialised once on the first call and reused
+ * on subsequent calls to avoid recreating the generator and
+ * distributions on every invocation.
+ *
+ * TODO: not thread-safe due to shared static state. If UUID generation
+ * is needed across multiple threads, add a mutex around this function.
+ * I must revisit in Milestone 3 when the auto-save thread is introduced.
+ *
+ */
+std::string generate_uuid4() {
+  static std::random_device rd;
+  static std::mt19937 mt(rd());
+  static std::uniform_int_distribution<> dist(0, 15);
+  static std::uniform_int_distribution<> dist2(8, 11);
+
+  std::stringstream ss;
+  int i;
+  ss << std::hex;
+
+  for (i = 0; i < 8; i++) ss << dist(mt);
+  ss << "-";
+  for (i = 0; i < 4; i++) ss << dist(mt);
+  ss << "-4";
+  for (i = 0; i < 3; i++) ss << dist(mt);
+  ss << "-";
+  ss << dist2(mt);
+  for (i = 0; i < 3; i++) ss << dist(mt);
+  ss << "-";
+  for (i = 0; i < 12; i++) ss << dist(mt);
+
+  return ss.str();
+}
+
+}  // namespace insura::domain

--- a/src/domain/uuid.hpp
+++ b/src/domain/uuid.hpp
@@ -1,0 +1,5 @@
+#include <string>
+
+namespace insura::domain {
+std::string generateUuid();
+}

--- a/src/domain/uuid.hpp
+++ b/src/domain/uuid.hpp
@@ -1,5 +1,0 @@
-#include <string>
-
-namespace insura::domain {
-std::string generateUuid();
-}

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -1,7 +1,81 @@
+#include <exception>
 #include <iostream>
+#include <memory>
+
+#include "application.hpp"
+#include "client_service.hpp"
+#include "csv_client_repository.hpp"
+
+// TODO: address autocomplete via geocoding API (Google Places or Nominatim) -
+// implement after TUI search is complete
+// TODO: at the end of the project, adjust all docs journal notes and remove the
+// - that AI added in each note
+// TODO: add in the readme the section that explains how I used AI
+
+/* Default filepath used when the user starts a fresh session without specifying
+ * one. Hardcoded for now.
+ * TODO: replace with a value read from a config file (e.g. insura.conf or
+ * ~/.insura/config). The config should store at minimum: default_filepath and
+ * optionally last_opened_filepath. main.cpp reads it here and passes the
+ * resolved path down — the repo stays unaware of any config. */
+static constexpr const char* kDefaultFilepath = "insura_data.csv";
 
 int main() {
-  std::cout << "Starting...\n";
+  int option;
+  std::cout << "Options\n";
+  std::cout << "1. New\n";
+  std::cout << "2. Load\n";
+  std::cin >> option;
+
+  std::unique_ptr<insura::data::CSVClientRepository> repo;
+
+  if (option == 1) {
+    std::string filepath;
+    std::cout << "Enter filepath for new CRM: ";
+    std::cin >> filepath;
+
+    repo = std::make_unique<insura::data::CSVClientRepository>(filepath);
+
+  } else if (option == 2) {
+    while (true) {
+      std::string filepath;
+      std::cout << "Enter filepath to load: ";
+      std::cin >> filepath;
+
+      repo = std::make_unique<insura::data::CSVClientRepository>(filepath);
+
+      try {
+        repo->load();
+        break;
+
+      } catch (const std::exception& e) {
+        std::cerr << e.what() << "\n";
+        std::cout << "1. Try again\n";
+        std::cout << "2. Start empty\n";
+
+        int retry;
+        std::cin >> retry;
+        if (retry == 1) {
+          continue;
+        } else if (retry == 2) {
+          repo = std::make_unique<insura::data::CSVClientRepository>(
+              kDefaultFilepath);
+          break;
+        } else {
+          std::cerr << "Invalid option\n";
+          continue;
+        }
+      }
+    }
+  } else {
+    std::cerr << "Invalid option\n";
+    return 1;
+  }
+
+  insura::service::ClientService client_service(*repo);
+  insura::cli::Application app(client_service, *repo);
+
+  app.run();
 
   return 0;
 }

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -1,5 +1,6 @@
 #include <exception>
 #include <iostream>
+#include <limits>
 #include <memory>
 
 #include "application.hpp"
@@ -25,14 +26,16 @@ int main() {
   std::cout << "Options\n";
   std::cout << "1. New\n";
   std::cout << "2. Load\n";
+  std::cout << "\n> ";
   std::cin >> option;
+  std::cin.ignore(std::numeric_limits<std::streamsize>::max(), '\n');
 
   std::unique_ptr<insura::data::CSVClientRepository> repo;
 
   if (option == 1) {
     std::string filepath;
     std::cout << "Enter filepath for new CRM: ";
-    std::cin >> filepath;
+    std::getline(std::cin, filepath);
 
     repo = std::make_unique<insura::data::CSVClientRepository>(filepath);
 
@@ -40,7 +43,7 @@ int main() {
     while (true) {
       std::string filepath;
       std::cout << "Enter filepath to load: ";
-      std::cin >> filepath;
+      std::getline(std::cin, filepath);
 
       repo = std::make_unique<insura::data::CSVClientRepository>(filepath);
 
@@ -55,6 +58,7 @@ int main() {
 
         int retry;
         std::cin >> retry;
+        std::cin.ignore(std::numeric_limits<std::streamsize>::max(), '\n');
         if (retry == 1) {
           continue;
         } else if (retry == 2) {

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -22,15 +22,16 @@
 static constexpr const char* kDefaultFilepath = "insura_data.csv";
 
 int main() {
-  int option;
+  std::string input;
   std::cout << "Options\n";
   std::cout << "1. New\n";
   std::cout << "2. Load\n";
   std::cout << "\n> ";
-  std::cin >> option;
-  std::cin.ignore(std::numeric_limits<std::streamsize>::max(), '\n');
+
+  std::getline(std::cin, input);
 
   std::unique_ptr<insura::data::CSVClientRepository> repo;
+  int option = std::stoi(input);
 
   if (option == 1) {
     std::string filepath;
@@ -56,9 +57,10 @@ int main() {
         std::cout << "1. Try again\n";
         std::cout << "2. Start empty\n";
 
-        int retry;
-        std::cin >> retry;
-        std::cin.ignore(std::numeric_limits<std::streamsize>::max(), '\n');
+        std::string option;
+        std::getline(std::cin, option);
+
+        int retry = std::stoi(option);
         if (retry == 1) {
           continue;
         } else if (retry == 2) {

--- a/src/service/client_service.cpp
+++ b/src/service/client_service.cpp
@@ -52,6 +52,22 @@ void ClientService::editClient(const std::string& uuid,
     throw std::invalid_argument("Error: No contact found");
   }
 
+  if (!new_client_data.first_name.empty()) {
+    client->setFirstName(new_client_data.first_name);
+  }
+
+  if (!new_client_data.last_name.empty()) {
+    client->setLastName(new_client_data.last_name);
+  }
+
+  if (!new_client_data.email.empty()) {
+    if (new_client_data.email != client->getEmail() &&
+        !isEmailUnique(new_client_data.email)) {
+      throw std::invalid_argument("Error: Email already used!");
+    }
+    client->setEmail(new_client_data.email);
+  }
+
   if (new_client_data.phone.has_value()) {
     client->setPhone(new_client_data.phone.value());
   }
@@ -78,6 +94,10 @@ void ClientService::editClient(const std::string& uuid,
 
   if (new_client_data.lead_status.has_value()) {
     client->setStatus(new_client_data.lead_status.value());
+  }
+
+  if (new_client_data.notes.has_value()) {
+    client->setNotes(new_client_data.notes.value());
   }
 
   /* Already checked if client is not empty, so using *client is safe */

--- a/src/service/client_service.cpp
+++ b/src/service/client_service.cpp
@@ -1,0 +1,103 @@
+#include "client_service.hpp"
+
+#include <stdexcept>
+
+/* TODO: I have to understand how to handle exception and
+ * where to put exceptions in C++
+ *
+ * Another idea could be to create specific domain errors and
+ * use them, e.g. functions like addClient return CRM_error_t
+ * type and it will be checked but I don't know, maybe it will
+ * be addressed later.
+ *
+ * */
+
+namespace insura::service {
+
+bool ClientService::isEmailUnique(const std::string& email) {
+  return !repo_.findByEmail(email).has_value();
+}
+
+void ClientService::addClient(const domain::ClientData& client_data) {
+  if (!isEmailUnique(client_data.email)) {
+    throw std::invalid_argument("Error: Email already used!");
+  }
+
+  auto status =
+      client_data.lead_status.value_or(domain::Client::ClientStatus::NEW);
+
+  domain::Client client(client_data.first_name, client_data.last_name,
+                        client_data.email, client_data.phone,
+                        client_data.job_title, client_data.company,
+                        client_data.address, client_data.city,
+                        client_data.postal_code, status, client_data.notes);
+
+  repo_.insertClient(client);
+}
+
+void ClientService::deleteClient(const std::string& uuid) {
+  if (!repo_.findByUuid(uuid).has_value())
+    throw std::invalid_argument("Error: No contact found");
+
+  repo_.removeClient(uuid);
+  /* I should also remove interaction and policies but I haven't
+   * implemented them yet */
+}
+
+void ClientService::editClient(const std::string& uuid,
+                               const domain::ClientData& new_client_data) {
+  auto client = repo_.findByUuid(uuid);
+
+  if (!client) {
+    throw std::invalid_argument("Error: No contact found");
+  }
+
+  if (new_client_data.phone.has_value()) {
+    client->setPhone(new_client_data.phone.value());
+  }
+
+  if (new_client_data.job_title.has_value()) {
+    client->setJobTitle(new_client_data.job_title.value());
+  }
+
+  if (new_client_data.company.has_value()) {
+    client->setCompany(new_client_data.company.value());
+  }
+
+  if (new_client_data.address.has_value()) {
+    client->setAddress(new_client_data.address.value());
+  }
+
+  if (new_client_data.city.has_value()) {
+    client->setCity(new_client_data.city.value());
+  }
+
+  if (new_client_data.postal_code.has_value()) {
+    client->setPostalCode(new_client_data.postal_code.value());
+  }
+
+  if (new_client_data.lead_status.has_value()) {
+    client->setStatus(new_client_data.lead_status.value());
+  }
+
+  /* Already checked if client is not empty, so using *client is safe */
+  repo_.updateClient(*client);
+}
+
+std::vector<domain::Client> ClientService::searchClients(
+    const std::string& search_term) {
+  std::vector<domain::Client> found;
+
+  auto clients = repo_.findAll();
+
+  for (const auto& client : clients) {
+    if (client.getFirstName().find(search_term) != std::string::npos ||
+        client.getLastName().find(search_term) != std::string::npos) {
+      found.push_back(client);
+    }
+  }
+
+  return found;
+}
+
+}  // namespace insura::service

--- a/src/service/client_service.hpp
+++ b/src/service/client_service.hpp
@@ -1,0 +1,22 @@
+#pragma once
+#include "../domain/client_data.hpp"
+#include "../domain/i_client_repository.hpp"
+
+namespace insura::service {
+
+class ClientService {
+ public:
+  ClientService(domain::IClientRepository& repo) : repo_(repo) {}
+  void addClient(const domain::ClientData& client_data);
+
+  void deleteClient(const std::string& uuid);
+  void editClient(const std::string& uuid,
+                  const domain::ClientData& new_client_data);
+  std::vector<domain::Client> searchClients(const std::string& search_term);
+
+ private:
+  bool isEmailUnique(const std::string& email);
+  domain::IClientRepository& repo_;
+};
+
+}  // namespace insura::service

--- a/src/service/client_service.hpp
+++ b/src/service/client_service.hpp
@@ -6,7 +6,7 @@ namespace insura::service {
 
 class ClientService {
  public:
-  ClientService(domain::IClientRepository& repo) : repo_(repo) {}
+  explicit ClientService(domain::IClientRepository& repo) : repo_(repo) {}
   void addClient(const domain::ClientData& client_data);
 
   void deleteClient(const std::string& uuid);


### PR DESCRIPTION
A user can now add, search, edit and delete clients through
the CLI menu. Data can be loaded from an existing CSV file
and saved back at any point during the session.

This PR covers the client-side workflow end-to-end, from
application startup to save and exit. The client view is
intentionally minimal since full detail display requires
Policy and Interaction data, which will be implemented in
subsequent PRs.

**Known limitations carried forward as open issues:**

- Status selection: lead_status defaults to NEW on creation.
  A selection menu for other values is not yet implemented.
- Case-sensitive search: searchClients will be made
  case-insensitive in a follow-up.
- Save on exit: the exit command shuts down immediately
  without warning about unsaved changes. Will be addressed
  using the dirty_ flag in a follow-up.

Built and manually tested with CMake. Automated tests are
not yet in place.