### PR TITLE
fix(data): resolve notes data loss and optional field corruption - closes #5

### DIFF
--- a/src/data/csv_client_repository.cpp
+++ b/src/data/csv_client_repository.cpp
@@ -119,7 +119,7 @@ std::string CSVClientRepository::serialize(const domain::Client& c) const {
   ss << c.getPostalCode().value_or("") << ",";
 
   ss << domain::statusToString(c.getStatus()) << ",";
-  ss << "" << ",";  // notes placeholder
+  ss << c.getNotes().value_or("") << ",";
   ss << c.getCreatedAt() << ",";
   ss << c.getUpdatedAt();
 
@@ -141,10 +141,6 @@ domain::Client CSVClientRepository::deserialize(const std::string& line) const {
   std::getline(ss, address, ',');
   std::getline(ss, city, ',');
   std::getline(ss, postal_code, ',');
-
-  /* TODO: handle status and notes and ensure the correct order:
-   * 1. status, 2. notes */
-
   std::getline(ss, status, ',');
   std::getline(ss, notes, ',');
   std::getline(ss, created_at, ',');

--- a/src/data/csv_client_repository.cpp
+++ b/src/data/csv_client_repository.cpp
@@ -127,6 +127,10 @@ std::string CSVClientRepository::serialize(const domain::Client& c) const {
 }
 
 domain::Client CSVClientRepository::deserialize(const std::string& line) const {
+  auto toOpt = [](const std::string& s) -> std::optional<std::string> {
+    return s.empty() ? std::nullopt : std::optional<std::string>{s};
+  };
+
   std::stringstream ss(line);
   std::string uuid, first, last, email, phone, job, company, address, city,
       postal_code, status, notes, created_at, updated_at;
@@ -148,9 +152,10 @@ domain::Client CSVClientRepository::deserialize(const std::string& line) const {
 
   domain::Client::ClientStatus lead_status = domain::statusFromString(status);
 
-  return domain::Client(uuid, first, last, email, phone, job, company, address,
-                        city, postal_code, lead_status, notes, created_at,
-                        updated_at);
+  return domain::Client(uuid, first, last, email, toOpt(phone), toOpt(job),
+                        toOpt(company), toOpt(address), toOpt(city),
+                        toOpt(postal_code), lead_status, toOpt(notes),
+                        created_at, updated_at);
 }
 
 }  // namespace insura::data


### PR DESCRIPTION
Notes entered by the user are now correctly serialized to CSV via
getNotes().value_or("").

On load, empty CSV fields were being passed as empty strings to the
loading constructor, which implicitly constructs std::optional{""}
rather than std::nullopt. has_value() then returns true for every
absent field, breaking all downstream optional checks especially
in the edit flow.

Fixed by adding a toOpt() lambda in deserialize() that converts
empty strings back to std::nullopt before construction.