### PR TITLE
feat(utils): implement string operations for normalization and search

### DIFF
--- a/src/cli/application.cpp
+++ b/src/cli/application.cpp
@@ -1,11 +1,13 @@
 #include "application.hpp"
 
+#include <cctype>
 #include <iostream>
 #include <regex>
 
 #include "client_service.hpp"
 #include "client_view.hpp"
 #include "menu.hpp"
+#include "strops.hpp"
 
 /*
  * Note before starting: I won't care about the menu and options
@@ -44,6 +46,7 @@ std::string promptRequired(const std::string& label) {
   do {
     std::cout << label;
     std::getline(std::cin, value);
+    value = insura::domain::strops::trim(value);
     if (value.empty()) std::cout << "  This field is required.\n";
   } while (value.empty());
   return value;
@@ -53,6 +56,7 @@ std::optional<std::string> promptOptional(const std::string& label) {
   std::string value;
   std::cout << label;
   std::getline(std::cin, value);
+  value = insura::domain::strops::trim(value);
   if (value.empty()) return std::nullopt;
   return value;
 }
@@ -84,7 +88,7 @@ void Application::cmdView() { std::cout << "Feature not implemented yet!"; }
 
 void Application::cmdConfig() { std::cout << "Feature not implemented yet!"; }
 
-void Application::cmdClear() { std::cout << "Feature not implemented yet!"; }
+void Application::cmdClear() { std::cout << "\033[2J\033[H"; }
 
 void Application::cmdAdd() {
   domain::ClientData data;
@@ -93,13 +97,16 @@ void Application::cmdAdd() {
   std::cout << "--- Add New Client ---\n";
 
   /* Required fields */
-  data.first_name = promptRequired("First name: ");
-  data.last_name = promptRequired("Last name: ");
+  std::string first = promptRequired("First name: ");
+  data.first_name = insura::domain::strops::capitalize(first);
+  std::string last = promptRequired("Last name: ");
+  data.last_name = insura::domain::strops::capitalize(last);
 
   while (true) {
     std::cout << "Email: ";
     std::string email;
     std::getline(std::cin, email);
+    email = insura::domain::strops::trim(email);
     if (email.empty()) {
       std::cout << "  This field is required.\n";
       continue;
@@ -108,7 +115,7 @@ void Application::cmdAdd() {
       std::cout << "  Invalid email format.\n";
       continue;
     }
-    data.email = std::move(email);
+    data.email = insura::domain::strops::lower(email);
     break;
   }
 
@@ -124,10 +131,18 @@ void Application::cmdAdd() {
     break;
   }
 
-  data.job_title = promptOptional("Job title (optional): ");
-  data.company = promptOptional("Company (optional): ");
-  data.address = promptOptional("Address (optional): ");
-  data.city = promptOptional("City (optional): ");
+  std::optional<std::string> job = promptOptional("Job title (optional): ");
+
+  data.job_title = job ? insura::domain::strops::capitalize(*job) : job;
+
+  std::optional<std::string> company = promptOptional("Company (optional): ");
+  data.company =
+      company ? insura::domain::strops::capitalize(*company) : company;
+
+  auto address = promptOptional("Address (optional): ");
+  data.address = address ? insura::domain::strops::capitalize(*address) : address;
+  std::optional<std::string> city = promptOptional("City (optional): ");
+  data.city = city ? insura::domain::strops::capitalize(*city) : city;
 
   while (true) {
     auto postal_code = promptOptional("Postal code (optional, digits only): ");
@@ -143,7 +158,8 @@ void Application::cmdAdd() {
   /* TODO: I should add an helper function for status that list
    * options and the user can select the status */
 
-  data.notes = promptOptional("Notes (optional): ");
+  auto notes = promptOptional("Notes (optional): ");
+  data.notes = notes ? insura::domain::strops::capitalize(*notes) : notes;
 
   try {
     client_service_.addClient(data);
@@ -189,6 +205,7 @@ std::optional<domain::Client> Application::resolveClient() {
      * I don't know if it is necessary since if the user select the
      * option, probably he wants to search something but maybe
      * it select the wrong option for a typing error */
+    term = insura::domain::strops::trim(term);
     if (term.empty()) continue;
 
     std::vector<domain::Client> found = client_service_.searchClients(term);
@@ -214,17 +231,27 @@ void Application::cmdSearch() {
   if (client) ClientView::displayOne(*client);
 }
 
+/* This function both prompts the user for updated field values and populates
+ * the ClientData struct — intentionally kept together, same pattern as
+ * cmdAdd. If a second non-CLI caller appears, the two responsibilities can
+ * be separated at that point. */
 domain::ClientData Application::promptEditData(const domain::Client& current) {
   domain::ClientData updated_data;
 
-  /* Required fields — shown with current value; leave blank to keep */
-  std::optional<std::string> first =
-      promptOptional("First name [" + current.getFirstName() + "]: ");
-  if (first) updated_data.first_name = std::move(*first);
+  {
+    /* Required fields — shown with current value; leave blank to keep */
+    std::optional<std::string> first =
+        promptOptional("First name [" + current.getFirstName() + "]: ");
+    if (first)
+      updated_data.first_name = insura::domain::strops::capitalize(*first);
+  }
 
-  std::optional<std::string> last =
-      promptOptional("Last name [" + current.getLastName() + "]: ");
-  if (last) updated_data.last_name = std::move(*last);
+  {
+    std::optional<std::string> last =
+        promptOptional("Last name [" + current.getLastName() + "]: ");
+    if (last)
+      updated_data.last_name = insura::domain::strops::capitalize(*last);
+  }
 
   while (true) {
     std::optional<std::string> email =
@@ -235,7 +262,7 @@ domain::ClientData Application::promptEditData(const domain::Client& current) {
       std::cout << "  Invalid email format.\n";
       continue;
     } else {
-      updated_data.email = std::move(*email);
+      updated_data.email = insura::domain::strops::lower(*email);
       break;
     }
   }
@@ -261,7 +288,9 @@ domain::ClientData Application::promptEditData(const domain::Client& current) {
         current.getJobTitle()
             ? "Job title [" + current.getJobTitle().value() + "]: "
             : "Job title (optional): ";
-    updated_data.job_title = promptOptional(prompt);
+    auto job_title = promptOptional(prompt);
+    updated_data.job_title =
+        job_title ? insura::domain::strops::capitalize(*job_title) : job_title;
   }
 
   {
@@ -269,7 +298,9 @@ domain::ClientData Application::promptEditData(const domain::Client& current) {
         current.getCompany()
             ? "Company [" + current.getCompany().value() + "]: "
             : "Company (optional): ";
-    updated_data.company = promptOptional(prompt);
+    auto company = promptOptional(prompt);
+    updated_data.company =
+        company ? insura::domain::strops::capitalize(*company) : company;
   }
 
   {
@@ -277,14 +308,16 @@ domain::ClientData Application::promptEditData(const domain::Client& current) {
         current.getAddress()
             ? "Address [" + current.getAddress().value() + "]: "
             : "Address (optional): ";
-    updated_data.address = promptOptional(prompt);
+    auto address = promptOptional(prompt);
+    updated_data.address = address ? insura::domain::strops::capitalize(*address) : address;
   }
 
   {
     std::string prompt = current.getCity()
                              ? "City [" + current.getCity().value() + "]: "
                              : "City (optional): ";
-    updated_data.city = promptOptional(prompt);
+    auto city = promptOptional(prompt);
+    updated_data.city = city ? insura::domain::strops::capitalize(*city) : city;
   }
 
   while (true) {
@@ -306,7 +339,8 @@ domain::ClientData Application::promptEditData(const domain::Client& current) {
     std::string prompt = current.getNotes()
                              ? "Notes [" + current.getNotes().value() + "]: "
                              : "Notes (optional): ";
-    updated_data.notes = promptOptional(prompt);
+    auto notes = promptOptional(prompt);
+    updated_data.notes = notes ? insura::domain::strops::capitalize(*notes) : notes;
   }
 
   return updated_data;
@@ -318,8 +352,16 @@ void Application::cmdDelete() {
   auto client = resolveClient();
   if (!client) return;
 
+  ClientView::displayOne(*client);
+  std::string choice;
+  std::cout << "\nAre you sure? (Y/n): ";
+  std::getline(std::cin, choice);
+
+  if (choice == "n") return;
+
   try {
     client_service_.deleteClient(client->getUuid());
+    std::cout << "Client eliminated successfully.\n";
   } catch (const std::invalid_argument& e) {
     std::cout << " Error: " << e.what() << "\n";
   }

--- a/src/domain/CMakeLists.txt
+++ b/src/domain/CMakeLists.txt
@@ -7,6 +7,7 @@ target_sources(insura_domain
     interaction.cpp
     utils.cpp
     client_status.cpp
+    strops.cpp
 )
 
 target_include_directories(insura_domain

--- a/src/domain/strops.cpp
+++ b/src/domain/strops.cpp
@@ -1,0 +1,57 @@
+#include <algorithm>
+#include <string>
+
+namespace insura::domain::strops {
+
+std::string lower(std::string s) {
+  std::transform(s.begin(), s.end(), s.begin(),
+                 [](unsigned char c) { return ::tolower(c); });
+  return s;
+}
+
+/* Trimming whitespaces and beginning and at the end, leaving intermediate ones
+ * maybe a check if between there are more than one space could be useful. */
+std::string trim(std::string s) {
+  /* trim starting from the left */
+  s.erase(s.begin(), std::find_if(s.begin(), s.end(), [](unsigned char c) {
+            return !std::isspace(c);
+          }));
+
+  /* trim starting from right */
+  s.erase(std::find_if(s.rbegin(), s.rend(),
+                       [](unsigned char c) { return !std::isspace(c); })
+              .base(),
+          s.end());
+
+  return s;
+}
+
+std::string capitalize(std::string s) {
+  /* Lowercase first so mixed-case input like "FRancesCo" is fully normalized
+   * before uppercasing word initials — without this step only the first char
+   * would be fixed while interior capitals survive. */
+  s = lower(std::move(s));
+
+  bool next = true;
+  for (auto& c : s) {
+    if (std::isspace(static_cast<unsigned char>(c))) {
+      next = true;
+    } else if (next) {
+      c = ::toupper(static_cast<unsigned char>(c));
+      next = false;
+    }
+  }
+
+  return s;
+}
+
+bool contains(const std::string& text, const std::string& query) {
+  auto it = std::search(text.begin(), text.end(), query.begin(), query.end(),
+                        [](unsigned char a, unsigned char b) {
+                          return ::tolower(a) == ::tolower(b);
+                        });
+
+  return it != text.end();
+}
+
+}  // namespace insura::domain::strops

--- a/src/domain/strops.hpp
+++ b/src/domain/strops.hpp
@@ -1,0 +1,10 @@
+#pragma once
+#include <string>
+namespace insura::domain::strops {
+
+std::string lower(std::string s);
+std::string capitalize(std::string s);
+std::string trim(std::string s);
+bool contains(const std::string& text, const std::string& query);
+
+}  // namespace insura::domain::strops

--- a/src/service/client_service.cpp
+++ b/src/service/client_service.cpp
@@ -2,6 +2,8 @@
 
 #include <stdexcept>
 
+#include "strops.hpp"
+
 /* TODO: I have to understand how to handle exception and
  * where to put exceptions in C++
  *
@@ -14,10 +16,15 @@
 
 namespace insura::service {
 
-bool ClientService::isEmailUnique(const std::string& email) {
+bool ClientService::isEmailUnique(const std::string& email) const {
   return !repo_.findByEmail(email).has_value();
 }
 
+/* Inputs in client_data are expected to be normalized by the caller (trimmed,
+ * capitalized, email lowercased). No normalization is performed here.
+ * If a non-CLI caller (e.g. a future BatchImportService) uses this method,
+ * it is responsible for preparing clean data before calling addClient.
+ */
 void ClientService::addClient(const domain::ClientData& client_data) {
   if (!isEmailUnique(client_data.email)) {
     throw std::invalid_argument("Error: Email already used!");
@@ -105,14 +112,14 @@ void ClientService::editClient(const std::string& uuid,
 }
 
 std::vector<domain::Client> ClientService::searchClients(
-    const std::string& search_term) {
+    const std::string& search_term) const {
   std::vector<domain::Client> found;
 
   auto clients = repo_.findAll();
 
   for (const auto& client : clients) {
-    if (client.getFirstName().find(search_term) != std::string::npos ||
-        client.getLastName().find(search_term) != std::string::npos) {
+    if (insura::domain::strops::contains(client.getFirstName(), search_term) ||
+        insura::domain::strops::contains(client.getLastName(), search_term)) {
       found.push_back(client);
     }
   }

--- a/src/service/client_service.hpp
+++ b/src/service/client_service.hpp
@@ -12,10 +12,11 @@ class ClientService {
   void deleteClient(const std::string& uuid);
   void editClient(const std::string& uuid,
                   const domain::ClientData& new_client_data);
-  std::vector<domain::Client> searchClients(const std::string& search_term);
+  std::vector<domain::Client> searchClients(
+      const std::string& search_term) const;
 
  private:
-  bool isEmailUnique(const std::string& email);
+  bool isEmailUnique(const std::string& email) const;
   domain::IClientRepository& repo_;
 };
 


### PR DESCRIPTION
Users can now search without worrying about letter casing and minor
input formatting inconsistencies are handled automatically by the
normalization layer.

Add strops module with lower(), capitalize(), trim() and contains()
helper functions.

Apply input normalization in the CLI layer: name fields are capitalized,
email is lowercased, leading and trailing whitespace is stripped from
all text input before storing.

Replace case-sensitive std::string::find in searchClients with
contains() using std::search and a tolower comparator, making
search case-insensitive with zero heap allocations.