### PR TITLE
Implement error handling strategy from audit - closes #11

### DIFF
--- a/src/cli/application.cpp
+++ b/src/cli/application.cpp
@@ -24,10 +24,14 @@ void Application::cmdConfig() { std::cout << "Feature not implemented yet!"; }
 void Application::cmdClear() { std::cout << "\033[2J\033[H"; }
 
 void Application::cmdSave() {
-  for (auto& [name, controller] : controllers_) {
-    controller->save();
+  try {
+    for (auto& [name, controller] : controllers_) {
+      controller->save();
+    }
+    std::cout << "  Data saved correctly.\n";
+  } catch (const std::exception& e) {
+    std::cerr << "  Error: " << e.what() << "\n";
   }
-  std::cout << "  Data saved correctly.\n";
 }
 
 void Application::cmdExit() {

--- a/src/cli/policy_controller.cpp
+++ b/src/cli/policy_controller.cpp
@@ -114,11 +114,20 @@ double previewPolicyAmount(insura::domain::Policy::PolicyType type,
                            int duration_months) {
   int col;
   switch (duration_months) {
-    case 6:  col = 0; break;
-    case 12: col = 1; break;
-    case 24: col = 2; break;
-    case 36: col = 3; break;
-    default: return 0.0;
+    case 6:
+      col = 0;
+      break;
+    case 12:
+      col = 1;
+      break;
+    case 24:
+      col = 2;
+      break;
+    case 36:
+      col = 3;
+      break;
+    default:
+      return 0.0;
   }
   return kDisplayPricingTable[static_cast<int>(type)][col];
 }
@@ -135,11 +144,11 @@ PolicyController::PolicyController(service::PolicyService& policy_service,
       policy_repo_(policy_repo),
       client_service_(client_service),
       client_repo_(client_repo) {
-  commands_["add"]    = [this]() { cmdAdd(); };
+  commands_["add"] = [this]() { cmdAdd(); };
   commands_["search"] = [this]() { cmdSearch(); };
-  commands_["list"]   = [this]() { cmdList(); };
-  commands_["view"]   = [this]() { cmdView(); };
-  commands_["edit"]   = [this]() { cmdEdit(); };
+  commands_["list"] = [this]() { cmdList(); };
+  commands_["view"] = [this]() { cmdView(); };
+  commands_["edit"] = [this]() { cmdEdit(); };
   commands_["delete"] = [this]() { cmdDelete(); };
 }
 

--- a/src/data/csv_client_repository.cpp
+++ b/src/data/csv_client_repository.cpp
@@ -1,5 +1,6 @@
 #include "csv_client_repository.hpp"
 
+#include <cassert>
 #include <filesystem>
 #include <optional>
 #include <sstream>
@@ -9,14 +10,6 @@
 #include "../domain/client_status.hpp"
 #include "../domain/utils.hpp"
 #include "file_handle.hpp"
-
-/* TODO: I have to remember to do defensive checks for operations
- *
- * But I think is not its responsibility?
- * I am not sure becasue the dirty flag is updated here and since it must be
- * updated only if operation succeed, I should make some checks.
- *
- * */
 
 namespace insura::data {
 
@@ -39,10 +32,9 @@ void CsvClientRepository::removeClient(std::string_view uuid) {
                            [uuid](const domain::Client& client) {
                              return client.getUuid() == uuid;
                            });
-  if (it != clients_.end()) {
-    clients_.erase(it, clients_.end());
-    dirty_ = true;
-  }
+  assert(it != clients_.end() && "removeClient: UUID not found");
+  clients_.erase(it, clients_.end());
+  dirty_ = true;
 }
 
 std::optional<domain::Client> CsvClientRepository::findByUuid(
@@ -75,10 +67,10 @@ void CsvClientRepository::updateClient(domain::Client updated) {
                            return c.getUuid() == updated.getUuid();
                          });
 
-  if (it != clients_.end()) {
-    *it = std::move(updated);
-    dirty_ = true;
-  }
+  assert(it != clients_.end() && "updateClient: UUID not found");
+
+  *it = std::move(updated);
+  dirty_ = true;
 }
 
 void CsvClientRepository::load() {
@@ -94,7 +86,7 @@ void CsvClientRepository::load() {
       }
     }
   } else {
-    throw std::runtime_error("Error: File doesn't exist");
+    throw std::runtime_error("file not found: " + filepath_);
   };
 
   clients_ = std::move(tmp_clients);
@@ -155,10 +147,12 @@ domain::Client CsvClientRepository::deserialize(const std::string& line) const {
 
   domain::Client::ClientStatus lead_status = domain::statusFromString(status);
 
-  return domain::Client(uuid, first, last, email, utils::stringToOptional(phone), utils::stringToOptional(job),
-                        utils::stringToOptional(company), utils::stringToOptional(address), utils::stringToOptional(city),
-                        utils::stringToOptional(postal_code), lead_status, utils::stringToOptional(notes),
-                        created_at, updated_at);
+  return domain::Client(
+      uuid, first, last, email, utils::stringToOptional(phone),
+      utils::stringToOptional(job), utils::stringToOptional(company),
+      utils::stringToOptional(address), utils::stringToOptional(city),
+      utils::stringToOptional(postal_code), lead_status,
+      utils::stringToOptional(notes), created_at, updated_at);
 }
 
 }  // namespace insura::data

--- a/src/data/csv_policy_repository.cpp
+++ b/src/data/csv_policy_repository.cpp
@@ -1,8 +1,10 @@
 #include "./csv_policy_repository.hpp"
 
 #include <algorithm>
+#include <cassert>
 #include <iterator>
 #include <sstream>
+#include <stdexcept>
 #include <string>
 
 #include "../domain/policy_status.hpp"
@@ -23,10 +25,9 @@ void CsvPolicyRepository::removePolicy(std::string_view uuid) {
       policies_.begin(), policies_.end(),
       [uuid](const domain::Policy& p) { return p.getUuid() == uuid; });
 
-  if (it != policies_.end()) {
-    policies_.erase(it, policies_.end());
-    dirty_ = true;
-  }
+  assert(it != policies_.end() && "removePolicy: UUID not found");
+  policies_.erase(it, policies_.end());
+  dirty_ = true;
 }
 
 std::optional<domain::Policy> CsvPolicyRepository::findByUuid(
@@ -81,10 +82,9 @@ void CsvPolicyRepository::updatePolicy(domain::Policy updated) {
                            return p.getUuid() == updated.getUuid();
                          });
 
-  if (it != policies_.end()) {
-    *it = std::move(updated);
-    dirty_ = true;
-  }
+  assert(it != policies_.end() && "updatePolicy: UUID not found");
+  *it = std::move(updated);
+  dirty_ = true;
 }
 
 std::string CsvPolicyRepository::serialize(const domain::Policy& p) const {
@@ -119,9 +119,16 @@ domain::Policy CsvPolicyRepository::deserialize(const std::string& line) const {
   std::getline(ss, created_at, ',');
   std::getline(ss, updated_at, ',');
 
+  double parsed_amount;
+  try {
+    parsed_amount = std::stod(amount);
+  } catch (const std::exception&) {
+    throw std::runtime_error("invalid amount in CSV: " + amount);
+  }
+
   return domain::Policy(uuid, client_uuid,
                         domain::policyTypeFromString(policy_type), start_date,
-                        utils::stringToOptional(end_date), std::stod(amount),
+                        utils::stringToOptional(end_date), parsed_amount,
                         domain::policyStatusFromString(policy_status),
                         utils::stringToOptional(notes), created_at, updated_at);
 }
@@ -142,7 +149,7 @@ void CsvPolicyRepository::load() {
       tmp_policies.push_back(deserialize(line));
     }
   } else {
-    throw std::runtime_error("Error: File doesn't exists");
+    throw std::runtime_error("file not found: " + filepath_);
   }
 
   policies_ = std::move(tmp_policies);

--- a/src/data/file_handle.cpp
+++ b/src/data/file_handle.cpp
@@ -8,7 +8,7 @@ FileHandler::FileHandler(std::string filepath, std::ios::openmode mode) {
   std::fstream file(filepath, mode);
 
   if (!file.is_open()) {
-    throw std::runtime_error("Error: Unable to open file!\n");
+    throw std::runtime_error("unable to open file: " + filepath);
   }
 
   file_ = std::move(file);

--- a/src/domain/client.cpp
+++ b/src/domain/client.cpp
@@ -1,5 +1,6 @@
 #include "client.hpp"
 
+#include <cassert>
 #include <stdexcept>
 
 #include "utils.hpp"
@@ -63,6 +64,8 @@ Client::Client(std::string first_name, std::string last_name, std::string email,
   }
 
   uuid_ = utils::generateUuid();
+  assert(!uuid_.empty() && "generateUuid returned empty string");
+
   first_name_ = std::move(first_name);
   last_name_ = std::move(last_name);
   email_ = std::move(email);

--- a/src/domain/client_status.cpp
+++ b/src/domain/client_status.cpp
@@ -22,6 +22,8 @@ std::string statusToString(insura::domain::Client::ClientStatus status) {
       return "closed_lost";
     case insura::domain::Client::ClientStatus::CLOSED_WON:
       return "closed_won";
+    default:
+      throw std::invalid_argument("unhandled client status value");
   }
 }
 
@@ -40,7 +42,7 @@ insura::domain::Client::ClientStatus statusFromString(std::string_view str) {
   if (str == "closed_won")
     return insura::domain::Client::ClientStatus::CLOSED_WON;
 
-  throw std::invalid_argument("Error: Unknown client status: " + std::string(str));
+  throw std::invalid_argument("unknown client status: " + std::string(str));
 }
 
 }  // namespace insura::domain

--- a/src/domain/policy.cpp
+++ b/src/domain/policy.cpp
@@ -1,5 +1,6 @@
 #include "policy.hpp"
 
+#include <cassert>
 #include <stdexcept>
 
 #include "utils.hpp"
@@ -20,18 +21,21 @@ Policy::Policy(std::string client_uuid, PolicyType policy_type,
     : client_uuid_(std::move(client_uuid))
 
 {
-  if (start_date.empty()) throw std::runtime_error("Start date can't be empty");
+  if (start_date.empty())
+    throw std::invalid_argument("start date cannot be empty");
 
   if (!utils::date::isValidDate(start_date))
-    throw std::runtime_error("Invalid date");
+    throw std::invalid_argument("invalid start date");
 
   if (end_date && !utils::date::isValidDate(end_date.value()))
-    throw std::runtime_error("Invalid date");
+    throw std::invalid_argument("invalid end date");
 
   if (amount <= 0)
-    throw std::invalid_argument("Amount must be greater than zero");
+    throw std::invalid_argument("amount must be greater than zero");
 
   uuid_ = utils::generateUuid();
+  assert(!uuid_.empty() && "generateUuid returned empty string");
+
   policy_type_ = policy_type;
   start_date_ = std::move(start_date);
 
@@ -86,23 +90,23 @@ void Policy::setPolicyStatus(PolicyStatus policy_status) {
 
 void Policy::setPolicyStartDate(const std::string& start_date) {
   if (start_date.empty())
-    throw std::invalid_argument("Start date can't be empty");
+    throw std::invalid_argument("start date cannot be empty");
   if (!utils::date::isValidDate(start_date))
-    throw std::invalid_argument("Invalid date");
+    throw std::invalid_argument("invalid start date");
   start_date_ = start_date;
   updated_at_ = utils::currentTimestamp();
 }
 
 void Policy::setPolicyEndDate(const std::string& end_date) {
   if (!utils::date::isValidDate(end_date))
-    throw std::invalid_argument("Invalid date");
+    throw std::invalid_argument("invalid end date");
   end_date_ = end_date;
   updated_at_ = utils::currentTimestamp();
 }
 
 void Policy::setPolicyAmount(double amount) {
   if (amount <= 0)
-    throw std::invalid_argument("Amount must be greater than zero");
+    throw std::invalid_argument("amount must be greater than zero");
   amount_ = amount;
   updated_at_ = utils::currentTimestamp();
 }

--- a/src/domain/policy_status.cpp
+++ b/src/domain/policy_status.cpp
@@ -15,6 +15,8 @@ std::string policyStatusToString(Policy::PolicyStatus status) {
       return "cancelled";
     case Policy::PolicyStatus::PENDING:
       return "pending";
+    default:
+      throw std::invalid_argument("unhandled policy status value");
   }
 }
 
@@ -24,8 +26,7 @@ Policy::PolicyStatus policyStatusFromString(std::string_view str) {
   if (str == "cancelled") return Policy::PolicyStatus::CANCELLED;
   if (str == "pending") return Policy::PolicyStatus::PENDING;
 
-  throw std::invalid_argument("Error: Unknown policy status: " +
-                              std::string(str));
+  throw std::invalid_argument("unknown policy status: " + std::string(str));
 }
 
 std::string policyTypeToString(Policy::PolicyType type) {
@@ -38,6 +39,8 @@ std::string policyTypeToString(Policy::PolicyType type) {
       return "health";
     case Policy::PolicyType::HOME:
       return "home";
+    default:
+      throw std::invalid_argument("unhandled policy type value");
   }
 }
 
@@ -47,8 +50,7 @@ Policy::PolicyType policyTypeFromString(std::string_view str) {
   if (str == "health") return Policy::PolicyType::HEALTH;
   if (str == "home") return Policy::PolicyType::HOME;
 
-  throw std::invalid_argument("Error: Unknown policy type: " +
-                              std::string(str));
+  throw std::invalid_argument("unknown policy type: " + std::string(str));
 }
 
 }  // namespace insura::domain

--- a/src/domain/strops.cpp
+++ b/src/domain/strops.cpp
@@ -27,10 +27,6 @@ std::string trim(std::string s) {
 }
 
 std::string capitalize(std::string s) {
-  /* Lowercase first so mixed-case input like "FRancesCo" is fully normalized
-   * before uppercasing word initials — without this step only the first char
-   * would be fixed while interior capitals survive. */
-  s = lower(std::move(s));
 
   bool next = true;
   for (auto& c : s) {

--- a/src/service/client_service.cpp
+++ b/src/service/client_service.cpp
@@ -1,5 +1,6 @@
 #include "client_service.hpp"
 
+#include <cassert>
 #include <stdexcept>
 
 #include "../domain/strops.hpp"
@@ -17,7 +18,7 @@ bool ClientService::isEmailUnique(std::string_view email) const {
  */
 void ClientService::addClient(const domain::ClientData& client_data) {
   if (!isEmailUnique(client_data.email)) {
-    throw std::invalid_argument("Error: Email already used!");
+    throw std::invalid_argument("email already in use");
   }
 
   auto status =
@@ -33,9 +34,13 @@ void ClientService::addClient(const domain::ClientData& client_data) {
 }
 
 void ClientService::deleteClient(std::string_view uuid) {
-  /* Ensure that after usage of uuid actually finds client */
-  if (!repo_.findByUuid(uuid).has_value())
-    throw std::invalid_argument("Error: No contact found");
+  /* I used assert for my exception strategy here but I've also kept
+   * the throw since if the function is called from another point
+   * like an API, the bug is catched in released mode. */
+
+  auto client = repo_.findByUuid(uuid);
+  assert(client.has_value() && "deleteClient: UUID not found");
+  if (!client) throw std::invalid_argument("client not found");
 
   std::vector<domain::Policy> client_policies =
       policies_.findByClientUuid(uuid);
@@ -49,11 +54,10 @@ void ClientService::deleteClient(std::string_view uuid) {
 
 void ClientService::editClient(std::string_view uuid,
                                const domain::ClientData& new_client_data) {
+  /* Same pattern used in deleteClient */
   auto client = repo_.findByUuid(uuid);
-
-  if (!client) {
-    throw std::invalid_argument("Error: No contact found");
-  }
+  assert(client.has_value() && "editClient: UUID not found");
+  if (!client) throw std::invalid_argument("client not found");
 
   if (!new_client_data.first_name.empty()) {
     client->setFirstName(new_client_data.first_name);
@@ -66,7 +70,7 @@ void ClientService::editClient(std::string_view uuid,
   if (!new_client_data.email.empty()) {
     if (new_client_data.email != client->getEmail() &&
         !isEmailUnique(new_client_data.email)) {
-      throw std::invalid_argument("Error: Email already used!");
+      throw std::invalid_argument("email already in use");
     }
     client->setEmail(new_client_data.email);
   }
@@ -107,7 +111,7 @@ void ClientService::editClient(std::string_view uuid,
    * *client is an lvalue (stored inside std::optional). std::move casts it to
    * an rvalue so updateClient move-constructs its by-value parameter instead of
    * copying. One unavoidable copy occurred when findByUuid returned into the
-   * optional — everything after is zero-copy.
+   * optional, everything after is zero-copy.
    */
   repo_.updateClient(std::move(*client));
 }

--- a/src/service/policy_service.cpp
+++ b/src/service/policy_service.cpp
@@ -2,6 +2,7 @@
 
 #include <cassert>
 #include <stdexcept>
+#include <string>
 
 #include "../domain/utils.hpp"
 
@@ -43,7 +44,8 @@ double PolicyService::calculateAmount(domain::Policy::PolicyType type,
       duration_to_index = 3;
       break;
     default:
-      throw std::invalid_argument("Error: Invalid duration");
+      throw std::invalid_argument("invalid duration months: " +
+                                  std::to_string(duration));
   }
 
   auto type_index = static_cast<int>(type);
@@ -55,7 +57,7 @@ void PolicyService::addPolicy(const domain::PolicyData& policy_data) {
    * end_date and amount are derived here per ADR-019, not supplied by the
    * caller. */
   if (!insura::utils::date::isValidDate(policy_data.start_date)) {
-    throw std::invalid_argument("Invalid start date: " +
+    throw std::invalid_argument("invalid start date: " +
                                 policy_data.start_date);
   }
 
@@ -74,8 +76,9 @@ void PolicyService::addPolicy(const domain::PolicyData& policy_data) {
 }
 
 void PolicyService::deletePolicy(std::string_view policy_uuid) {
-  if (!policy_repo_.findByUuid(policy_uuid))
-    throw std::invalid_argument("Error: No Policy found");
+  auto policy = policy_repo_.findByUuid(policy_uuid);
+  assert(policy.has_value() && "deletePolicy: UUID not found");
+  if (!policy) throw std::invalid_argument("policy not found");
 
   policy_repo_.removePolicy(policy_uuid);
 }
@@ -83,10 +86,8 @@ void PolicyService::deletePolicy(std::string_view policy_uuid) {
 void PolicyService::editPolicy(std::string_view policy_uuid,
                                const domain::PolicyData& update_policy_data) {
   auto policy = policy_repo_.findByUuid(policy_uuid);
-
-  if (!policy) {
-    throw std::invalid_argument("Error: No Policy found");
-  }
+  assert(policy.has_value() && "editPolicy: UUID not found");
+  if (!policy) throw std::invalid_argument("policy not found");
 
   /* editPolicy only accepts status and notes because all other fields are
    * immutable contract-defining fields per ADR-019. */


### PR DESCRIPTION
**Description**
Implements the error handling strategy defined in ADR-020. Adds
runtime asserts for programmer error preconditions, applies
belt-and-suspenders to destructive service operations, standardizes
exception types and message formats, and sets up the Catch2 test
framework.

**Changes**
- 8 assert() checks added: UUID generation (Client, Policy),
  repository update/remove (CsvClientRepository, CsvPolicyRepository)
- 4 service functions updated with assert + throw pattern:
  deleteClient, editClient, deletePolicy, editPolicy
- Policy constructor: 3 std::runtime_error changed to
  std::invalid_argument for consistency with setters
- Default cases added to statusToString, policyStatusToString,
  policyTypeToString for unhandled enum values
- Error messages standardized to lowercase across all layers
- std::stod wrapped in try/catch in policy CSV deserialize
- cmdSave wrapped in try/catch for I/O error recovery
- capitalize() no longer lowercases before capitalizing