### PR TITLE
feat: add configuration system with startup file parsing - closes #14

### DIFF
--- a/docs/adr/ADR-023.md
+++ b/docs/adr/ADR-023.md
@@ -1,0 +1,80 @@
+## ADR-023: Configuration System Design
+
+**Date:** May 2026
+**Status:** DECIDED
+
+### Context
+
+The CRM needs user-configurable settings for default directory,
+filenames, and auto-save parameters. The configuration is read at
+startup and applies for the entire session (startup-only, not
+editable mid-session).
+
+### Options Considered
+
+**Option A: Git-style layered config parsing**
+
+Git uses a multi-layered configuration system: system-wide, user-level,
+and repository-level config files that override each other. Parsing
+dispatches each variable to a type-specific callback function
+(git_config_bool, git_config_int, git_config_string) based on a
+section.key naming scheme (e.g., core.autocrlf, user.name). Each
+section has its own parsing function that switches on the variable
+name and calls the appropriate type converter.
+
+This approach scales to hundreds of configuration keys across multiple
+scopes with complex validation rules and inheritance between layers.
+
+**Option B: Single flat file with inline validation**
+
+One key=value file read at startup. A single parseConfig function
+reads the file line by line, splits on the first "=", and passes
+each key-value pair to applyConfigLine which matches the key with
+if/else and validates inline. Invalid values print a warning and
+keep the default. Unknown keys are ignored with a warning. Comments
+(lines starting with #) and empty lines are skipped.
+
+No sections, no layering, no type-specific callback system.
+
+### Decision
+
+**Option B.** Single flat file with inline validation.
+
+### Rationale
+
+The CRM has five configuration fields. Git has hundreds across
+multiple scopes. Building a section-based dispatcher with typed
+callbacks for five fields is over-engineering. The flat file approach
+is proportional: one struct with in-class defaults, one parse function,
+one apply function. Adding a sixth field means adding one else-if
+branch, not a new section parser.
+
+If the config grows beyond 15-20 fields, revisit this decision and
+consider extracting type-specific validators. For five fields, inline
+validation is readable and maintainable.
+
+### File format
+
+    # InsuraPro CRM Configuration
+    default_directory=insurapro_data
+    clients_filename=clients.csv
+    policies_filename=policies.csv
+    autosave_enabled=true
+    autosave_interval_seconds=60
+
+One key=value per line. # for comments. Empty lines ignored. No
+sections, no quoting, no escaping. The parser splits on the first
+"=" only, so values can contain "=" if needed.
+
+### Implementation
+
+CrmConfig struct with in-class defaults lives in main.cpp anonymous
+namespace. parseConfig() reads from a fixed path (insurapro.conf in
+the project root). If the file is missing, the default config is used
+silently. applyConfigLine() validates each value before setting:
+isValidCsvFile for filenames, "true"/"false" for booleans, std::stoi
+with positive check for the interval. Invalid values fall back to
+defaults with a warning to stderr.
+
+The config file is not managed by the application. The user edits it
+directly, same as .gitconfig. No config command in the menu.

--- a/insurapro.conf
+++ b/insurapro.conf
@@ -1,0 +1,7 @@
+# Crm config options
+autosave_enabled=true
+autosave_interval_seconds=60
+default_directory=insurapro_data
+clients_filename=clients.csv
+policies_filename=policies.csv
+interactions_filename=interactions.csv

--- a/src/cli/application.cpp
+++ b/src/cli/application.cpp
@@ -19,8 +19,6 @@ Application::Application(service::ClientService& client_service,
       policy_service, policy_repo, client_service, client_repo);
 }
 
-void Application::cmdConfig() { std::cout << "Feature not implemented yet!"; }
-
 void Application::cmdClear() { std::cout << "\033[2J\033[H"; }
 
 void Application::cmdSave() {

--- a/src/cli/application.hpp
+++ b/src/cli/application.hpp
@@ -30,7 +30,6 @@ class Application {
   void cmdSave();
   void cmdExit();
   void cmdClear();
-  void cmdConfig();
 };
 
 }  // namespace insura::cli

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -6,7 +6,9 @@
 #include "./cli/application.hpp"
 #include "./data/csv_client_repository.hpp"
 #include "./data/csv_policy_repository.hpp"
+#include "./data/file_handle.hpp"
 #include "./domain/strops.hpp"
+#include "./domain/utils.hpp"
 #include "./service/client_service.hpp"
 #include "./service/policy_service.hpp"
 
@@ -29,7 +31,91 @@
  * resolved path down — the repo stays unaware of any config. */
 
 namespace {
-static constexpr const char* kDefaultDir = "insurapro_data";
+
+struct CrmConfig {
+  std::string default_directory = "insurapro_data";
+  std::string clients_filename = "clients.csv";
+  std::string policies_filename = "policies.csv";
+  bool autosave_enabled = true;
+  int autosave_interval_seconds = 60;
+};
+
+static constexpr const char* config_path = "insurapro.conf";
+
+void applyConfigLine(CrmConfig& config, const std::string& key,
+                     const std::string& value) {
+  if (key == "default_directory") {
+    config.default_directory = value;
+  } else if (key == "clients_filename") {
+    if (!insura::utils::isValidCsvFile(value)) {
+      std::cerr << "\nConfig warning [" << key << "]: '" << value
+                << "' is not a valid CSV filename. Default used: "
+                << config.clients_filename << "\n";
+      return;
+    }
+    config.clients_filename = value;
+  } else if (key == "policies_filename") {
+    if (!insura::utils::isValidCsvFile(value)) {
+      std::cerr << "\nConfig warning [" << key << "]: '" << value
+                << "' is not a valid CSV filename. Default used: "
+                << config.policies_filename << "\n";
+      return;
+    }
+    config.policies_filename = value;
+  } else if (key == "autosave_enabled") {
+    if (value != "true" && value != "false") {
+      auto default_value = config.autosave_enabled ? "true" : "false";
+
+      std::cerr << "\nConfig warning [" << key << "]: '" << value
+                << "' is not a valid boolean (expected \"true\" or \"false\"). "
+                   "Default used: "
+                << default_value << "\n";
+      return;
+    }
+    config.autosave_enabled = (value == "true");
+  } else if (key == "autosave_interval_seconds") {
+    try {
+      int interval = std::stoi(value);
+      if (interval <= 0) {
+        std::cerr << "\nConfig warning [" << key << "]: '" << value
+                  << "' is not a positive intege. Default used: "
+                  << config.autosave_interval_seconds << "\n";
+        return;
+      }
+      config.autosave_interval_seconds = interval;
+    } catch (...) {
+      std::cerr << "\nConfig warning [" << key << "]: '" << value
+                << "' is not a valid integer. Default used: "
+                << config.autosave_interval_seconds << "\n";
+    }
+  } else {
+    std::cerr << "\nConfig warning [" << key
+              << "]: unrecognized option. Ignored.\n";
+  }
+}
+
+CrmConfig parseConfig() {
+  CrmConfig config;
+  if (!std::filesystem::exists(config_path)) return config;
+
+  insura::data::FileHandler in(config_path, std::ios::in);
+  std::string line;
+
+  while (std::getline(in.getStream(), line)) {
+    line = insura::domain::strops::trim(line);
+    if (line.empty() || line[0] == '#') continue;
+
+    auto pos = line.find('=');
+    if (pos == std::string::npos) continue;
+
+    std::string key = insura::domain::strops::trim(line.substr(0, pos));
+    std::string value = insura::domain::strops::trim(line.substr(pos + 1));
+
+    applyConfigLine(config, key, value);
+  }
+
+  return config;
+}
 
 constexpr int kInitWidth = 16;
 
@@ -50,19 +136,20 @@ struct CrmRepositories {
 
 void cmdExit() { std::exit(0); }
 
-CrmRepositories cmdNew() {
+CrmRepositories cmdNew(const CrmConfig& config) {
   std::string dirpath;
-  std::cout << "Enter the directory path (default: " << kDefaultDir << "): ";
+  std::cout << "Enter the directory path (default: " << config.default_directory
+            << "): ";
   std::getline(std::cin, dirpath);
 
-  if (dirpath.empty()) dirpath = kDefaultDir;
+  if (dirpath.empty()) dirpath = config.default_directory;
 
   if (!std::filesystem::exists(dirpath)) {
     std::filesystem::create_directory(dirpath);
   }
 
-  std::string client_path = dirpath + "/clients.csv";
-  std::string policy_path = dirpath + "/policies.csv";
+  std::string client_path = dirpath + "/" + config.clients_filename;
+  std::string policy_path = dirpath + "/" + config.policies_filename;
 
   CrmRepositories repositories;
   repositories.client_repo =
@@ -73,7 +160,7 @@ CrmRepositories cmdNew() {
   return repositories;
 }
 
-CrmRepositories cmdLoad() {
+CrmRepositories cmdLoad(const CrmConfig& config) {
   while (true) {
     std::string dirpath;
     std::cout << "Enter the directory path to load: ";
@@ -103,8 +190,8 @@ CrmRepositories cmdLoad() {
       if (choice == "retry") continue;
       if (choice == "new") {
         std::filesystem::create_directory(dirpath);
-        std::string client_path = dirpath + "/clients.csv";
-        std::string policy_path = dirpath + "/policies.csv";
+        std::string client_path = dirpath + "/" + config.clients_filename;
+        std::string policy_path = dirpath + "/" + config.policies_filename;
 
         CrmRepositories repositories;
         repositories.client_repo =
@@ -119,8 +206,8 @@ CrmRepositories cmdLoad() {
       continue;
     }
 
-    std::string client_path = dirpath + "/clients.csv";
-    std::string policy_path = dirpath + "/policies.csv";
+    std::string client_path = dirpath + "/" + config.clients_filename;
+    std::string policy_path = dirpath + "/" + config.policies_filename;
 
     CrmRepositories repositories;
     repositories.client_repo =
@@ -148,6 +235,7 @@ CrmRepositories cmdLoad() {
 }  // namespace
 
 int main() {
+  CrmConfig config = parseConfig();
   CrmRepositories repos;
 
   while (true) {
@@ -158,10 +246,10 @@ int main() {
     option = insura::domain::strops::trim(option);
 
     if (option == "new") {
-      repos = cmdNew();
+      repos = cmdNew(config);
       break;
     } else if (option == "load") {
-      repos = cmdLoad();
+      repos = cmdLoad(config);
       if (repos.client_repo && repos.policy_repo) break;
     } else if (option == "exit") {
       cmdExit();


### PR DESCRIPTION
**Description**

Adds a configuration system that reads settings from a flat
key=value file (insurapro.conf) at startup. All settings have
sensible defaults so the CRM works without a config file.
Configuration is startup-only, not editable mid-session.

**Changes**

- CrmConfig struct in main.cpp anonymous namespace with five
  fields and in-class defaults
- parseConfig() reads the config file, applyConfigLine() validates
  and sets each field per key
- cmdNew and cmdLoad use config values for directory and filenames
  instead of hardcoded strings
- cmdConfig removed from Application (header and implementation)
- Validation: isValidCsvFile for filenames, "true"/"false" for
  booleans, positive integer check for interval
- Unknown keys and invalid values produce stderr warnings

**Testing done**

- Verified missing config file starts with all defaults
- Verified valid config file overrides defaults correctly
- Verified invalid values (bad filename, bad boolean, negative
  interval) produce warnings and keep defaults
- Verified unknown keys produce warnings and are ignored
- Built in debug mode, zero errors

**Notes**

Config file format documented in ADR-023. The autosave_enabled
and autosave_interval_seconds fields are parsed and stored but
not yet used. They will be consumed by the auto-save thread in
the next issue.