### PR TITLE
Feature/autosave thread - closes #15

### DIFF
--- a/docs/adr/ADR-024.md
+++ b/docs/adr/ADR-024.md
@@ -54,6 +54,17 @@ A single centralized mutex would block unrelated operations.
 Neither AutoSaveService nor Application touches any mutex directly.
 The repositories manage their own thread safety internally.
 
+**findAll returns by value, not by reference.**
+
+Previously findAll returned const std::vector<Client>& (a reference
+to the internal vector). With threading, the lock releases when
+findAll returns but the caller holds the reference. Any write from
+another thread that reallocates the vector (insert, remove) invalidates
+the reference: undefined behavior. Changed to return std::vector<Client>
+by value. The copy happens while the lock is held, giving the caller
+a consistent snapshot independent of subsequent modifications. The
+copy cost is negligible for CLI-scale data volumes.
+
 **UUID thread-safety**
 
 generateUuid in utils.cpp uses a shared static mt19937 random

--- a/docs/adr/ADR-024.md
+++ b/docs/adr/ADR-024.md
@@ -1,0 +1,119 @@
+## ADR-024: Auto-Save Service Design
+
+**Date:** May 2026
+**Status:** DECIDED
+
+### Context
+
+The CRM needs periodic background saving so user data is not lost
+if the program crashes or the user forgets to save manually. The
+auto-save must not block the CLI: the user should be able to type
+commands while saving happens in the background.
+
+### Decision
+
+**AutoSaveService as a standalone class**
+
+AutoSaveService lives in src/service/. It owns a std::thread, a
+std::condition_variable, a stop flag, and a mutex for the condition
+variable. It receives two parameters at construction: a
+std::function<void()> save callable and an int interval in seconds.
+
+Application binds its cmdSave method to the save callable. This
+means AutoSaveService saves everything (all controllers, all
+repositories) without knowing about controllers, repositories, or
+entity types. If a new entity is added, only cmdSave changes.
+
+**Thread lifecycle**
+
+The thread is created inside start(), which is called from the
+constructor. The thread runs a loop: wait_for on the condition
+variable with the configured interval, then call the save callable
+if any data is dirty. The loop exits when the stop flag is set.
+
+Stop() sets the stop flag to true, notifies the condition variable
+(waking the thread immediately regardless of remaining interval),
+and calls join() to wait for the thread to finish.
+
+AutoSaveService is only constructed when the config option
+autosave_enabled is true. If disabled, no object is created and
+no thread exists.
+
+**Mutex ownership: each repository protects its own data**
+
+Each repository (CsvClientRepository, CsvPolicyRepository) has its
+own std::mutex as a private member. Every method that accesses the
+data vector (insert, update, remove, findByUuid, findByEmail,
+findAll, save, load) locks the mutex using std::lock_guard at the
+start of the method.
+
+Separate mutexes per repository allow more concurrency: the main
+thread can insert a client while auto-save writes policies to disk.
+A single centralized mutex would block unrelated operations.
+
+Neither AutoSaveService nor Application touches any mutex directly.
+The repositories manage their own thread safety internally.
+
+**UUID thread-safety**
+
+generateUuid in utils.cpp uses a shared static mt19937 random
+engine. Two threads calling it simultaneously is a data race. A
+std::mutex is added around the engine inside generateUuid. This is
+the only shared mutable state outside the repositories.
+
+**Shutdown flow and dirty flag interaction**
+
+The auto-save thread is not responsible for the final save at
+shutdown. The exit workflow owns the shutdown save decision:
+
+1. User types exit
+2. Application checks if any controller reports isDirty
+3. If dirty: prompts "Save before exiting? (Y/n)"
+4. If yes: Application calls cmdSave (main thread saves)
+5. Application calls stop() on AutoSaveService
+6. AutoSaveService sets stop flag, notifies condition variable
+7. Auto-save thread wakes immediately, sees stop flag, exits loop
+   without saving (main thread already handled it)
+8. Application calls join, waits for thread to finish, program ends
+
+The dirty flag is protected by the repository mutex so both threads
+can check and modify it safely. After auto-save or manual save runs,
+dirty is reset to false. The exit prompt only appears when data has
+changed since the last save, regardless of which thread performed
+that save.
+
+### Rationale
+
+**Why a class, not a loose thread in Application:** bundling the
+thread, condition variable, stop flag, and interval into a class
+keeps Application thin. Application calls start (via construction)
+and stop. All concurrency details are encapsulated.
+
+**Why std::function<void()> instead of passing controllers:**
+AutoSaveService does not need to know about controllers, entities,
+or the number of repositories. It calls a function that saves
+everything. This decouples auto-save from the CRM's domain model.
+
+**Why lock_guard, not unique_lock, in repositories:** repository
+methods lock at the start and unlock at the end of scope. No manual
+unlock or condition variable wait is needed. lock_guard is the
+simplest and lightest tool for this pattern.
+
+**Why unique_lock in AutoSaveService:** the condition_variable::wait_for
+call requires unique_lock because wait must unlock the mutex while
+sleeping and relock when woken. lock_guard cannot do this.
+
+**Why separate mutexes per repository, not one global mutex:** the
+data is independent (clients and policies are separate vectors in
+separate files). A global mutex would block the main thread from
+reading clients while auto-save writes policies, which is
+unnecessary serialization.
+
+### Impact
+
+New files: src/service/auto_save_service.hpp, auto_save_service.cpp.
+
+Modified: both CSV repository classes (add mutex member and
+lock_guard in every method), utils.cpp (add mutex around UUID
+generation), Application (construct/destroy AutoSaveService),
+main.cpp (pass config interval to Application).

--- a/docs/daily_logs/2026-05-16.md
+++ b/docs/daily_logs/2026-05-16.md
@@ -1,0 +1,32 @@
+**May 13, 2026**
+
+**Active branch:** feature/autosave-thread
+**Issue:** Auto-save thread
+
+**What I built:**
+- Studied concurrency fundamentals: threads, mutex, lock_guard, unique_lock, condition_variable, data races, deadlock
+- Watched CppCon "Back to Basics: Concurrency" by Mike Shah
+- Read A Tour of C++ Chapter 18 (Concurrency)
+- Designed AutoSaveService class through iterative reasoning: constructor signature, member layout, start/stop interface, thread lifecycle
+- Wrote initial AutoSaveService header skeleton
+
+**What I learned:**
+- std::thread starts executing immediately on construction. A thread must be joined or detached before going out of scope, otherwise std::terminate is called
+- Threads do not execute in creation order. The OS scheduler decides which thread runs when. Vector storage order is not execution order
+- std::lock_guard locks on construction, unlocks on destruction (RAII). Use for simple scope protection. std::unique_lock supports manual unlock/relock, required by condition_variable because wait() must unlock the mutex while sleeping
+- std::condition_variable::wait_for combines a timeout with a stop signal. The auto-save thread either wakes when the interval expires (time to save) or when the main thread notifies (time to shut down)
+- Deadlock requires two or more locks held simultaneously by different threads in circular dependency. With one mutex, deadlock is impossible. Forgetting to unlock is not deadlock but resource starvation, prevented by lock_guard
+- Static local variable initialization is thread-safe since C++11 (only the first construction is protected, not subsequent access)
+- Lock-free programming uses atomic operations to avoid mutexes. Exists for high-contention systems (many threads, frequent lock acquisitions). Not applicable to the CRM: two threads with one lock every 60 seconds is negligible contention
+- Memory ordering is handled automatically by std::mutex (acquire on lock, release on unlock). No need to think about it when using mutex
+- Each repository owns its own mutex protecting its own data. Separate mutexes allow more concurrency: main thread can insert a client while auto-save writes policies. A single centralized mutex would unnecessarily block unrelated operations
+
+**Architecture reasoning:**
+
+- AutoSaveService is a standalone class in src/service/. It receives a std::function<void()> (the save callable) and an int interval in seconds. Application binds its cmdSave to the callable, so AutoSaveService saves everything without knowing about controllers or repositories.
+- The mutex lives inside each repository, not in Application or AutoSaveService. Every repository method that touches the data vector (insert, update, remove, find, save, load) locks the mutex internally. Neither AutoSaveService nor Application ever touches the mutex directly. This means the repository protects its own data, consistent with the layered architecture.
+- The auto-save thread is not responsible for the final save at shutdown. The exit workflow in Application::cmdExit owns the shutdown save decision (check dirty, prompt user, save if yes). The auto-save thread is stopped after the user decides, and it exits without doing a final save since the main thread already handled it.
+- Start creates the thread running a loop. Stop sets the stop flag, notifies the condition variable (waking the thread immediately regardless of remaining interval time), and joins. The thread is a class member so it lives for the lifetime of the AutoSaveService object.
+
+**Next session:**
+Complete AutoSaveService implementation: the loop function using wait_for, start() creating the thread, stop() with flag and notify and join. Add mutex to both repositories with lock_guard on every data-accessing method. Fix UUID thread-safety. Wire into Application constructor and cmdExit. Test with a short interval.

--- a/src/cli/application.cpp
+++ b/src/cli/application.cpp
@@ -3,13 +3,15 @@
 #include <iostream>
 
 #include "../domain/strops.hpp"
+#include "../service/auto_save_service.hpp"
 #include "client_controller.hpp"
 #include "menu.hpp"
 #include "policy_controller.hpp"
 
 namespace insura::cli {
 
-Application::Application(service::ClientService& client_service,
+Application::Application(bool autosave_enabled, int autosave_interval,
+                         service::ClientService& client_service,
                          domain::IClientRepository& client_repo,
                          service::PolicyService& policy_service,
                          domain::IPolicyRepository& policy_repo) {
@@ -17,25 +19,33 @@ Application::Application(service::ClientService& client_service,
       client_service, client_repo, policy_service);
   controllers_["policies"] = std::make_unique<PolicyController>(
       policy_service, policy_repo, client_service, client_repo);
+
+  if (autosave_enabled) {
+    autosave_.emplace([this] { cmdSave(true); }, autosave_interval);
+  }
 }
 
 void Application::cmdClear() { std::cout << "\033[2J\033[H"; }
 
-void Application::cmdSave() {
+void Application::cmdSave(bool silent) {
   try {
     for (auto& [name, controller] : controllers_) {
       controller->save();
     }
-    std::cout << "  Data saved correctly.\n";
+    if (!silent) std::cout << "Data saved correctly.\n";
   } catch (const std::exception& e) {
-    std::cerr << "  Error: " << e.what() << "\n";
+    std::cerr << "Error: " << e.what() << "\n";
   }
 }
 
 void Application::cmdExit() {
+  if (autosave_) autosave_->stop();
   bool any_dirty = false;
   for (auto& [name, controller] : controllers_) {
-    if (controller->isDirty()) { any_dirty = true; break; }
+    if (controller->isDirty()) {
+      any_dirty = true;
+      break;
+    }
   }
 
   if (any_dirty) {
@@ -43,7 +53,7 @@ void Application::cmdExit() {
     std::cout << "Save before exiting? (Y/n): ";
     std::getline(std::cin, choice);
     choice = domain::strops::trim(choice);
-    if (choice != "n") cmdSave();
+    if (choice != "n") cmdSave(false);
   }
 
   std::cout << "Closing session.\n";
@@ -52,7 +62,7 @@ void Application::cmdExit() {
 
 bool Application::handleAppCmds(const std::string& cmd) {
   if (cmd == "save") {
-    cmdSave();
+    cmdSave(false);
     return true;
   } else if (cmd == "exit") {
     cmdExit();

--- a/src/cli/application.hpp
+++ b/src/cli/application.hpp
@@ -5,6 +5,7 @@
 
 #include "../domain/i_client_repository.hpp"
 #include "../domain/i_policy_repository.hpp"
+#include "../service/auto_save_service.hpp"
 #include "../service/client_service.hpp"
 #include "../service/policy_service.hpp"
 #include "i_entity_controller.hpp"
@@ -13,7 +14,8 @@ namespace insura::cli {
 
 class Application {
  public:
-  Application(service::ClientService& client_service,
+  Application(bool autosave_enabled, int autosave_interval,
+              service::ClientService& client_service,
               domain::IClientRepository& client_repo,
               service::PolicyService& policy_service,
               domain::IPolicyRepository& policy_repo);
@@ -21,13 +23,14 @@ class Application {
 
  private:
   bool running_ = false;
+  std::optional<service::AutoSaveService> autosave_;
   std::unordered_map<std::string, std::unique_ptr<IEntityController>>
       controllers_;
   IEntityController* active_controller_ = nullptr;
   bool handleAppCmds(const std::string& option);
 
   /* Application-level commands */
-  void cmdSave();
+  void cmdSave(bool silent);
   void cmdExit();
   void cmdClear();
 };

--- a/src/data/csv_client_repository.cpp
+++ b/src/data/csv_client_repository.cpp
@@ -2,6 +2,7 @@
 
 #include <cassert>
 #include <filesystem>
+#include <mutex>
 #include <optional>
 #include <sstream>
 #include <stdexcept>
@@ -23,11 +24,13 @@ CsvClientRepository::CsvClientRepository(std::string filepath)
  * from NRVO, so return-by-value also costs nothing.
  */
 void CsvClientRepository::insertClient(domain::Client client) {
+  std::lock_guard<std::mutex> lock(mtx_);
   clients_.push_back(std::move(client));
   dirty_ = true;
 }
 
 void CsvClientRepository::removeClient(std::string_view uuid) {
+  std::lock_guard<std::mutex> lock(mtx_);
   auto it = std::remove_if(clients_.begin(), clients_.end(),
                            [uuid](const domain::Client& client) {
                              return client.getUuid() == uuid;
@@ -39,6 +42,7 @@ void CsvClientRepository::removeClient(std::string_view uuid) {
 
 std::optional<domain::Client> CsvClientRepository::findByUuid(
     std::string_view uuid) const {
+  std::lock_guard<std::mutex> lock(mtx_);
   auto it = std::find_if(
       clients_.begin(), clients_.end(),
       [uuid](const domain::Client& c) { return c.getUuid() == uuid; });
@@ -49,6 +53,7 @@ std::optional<domain::Client> CsvClientRepository::findByUuid(
 
 std::optional<domain::Client> CsvClientRepository::findByEmail(
     std::string_view email) const {
+  std::lock_guard<std::mutex> lock(mtx_);
   auto it = std::find_if(
       clients_.begin(), clients_.end(),
       [email](const domain::Client& c) { return c.getEmail() == email; });
@@ -57,11 +62,19 @@ std::optional<domain::Client> CsvClientRepository::findByEmail(
   return *it;
 }
 
-const std::vector<domain::Client>& CsvClientRepository::findAll() const {
+/* Returns by value, not by reference. Returning a reference would
+ * allow the caller to hold a pointer into the internal vector after
+ * the mutex is released. Any write from another thread that triggers
+ * reallocation would invalidate that pointer (undefined behavior).
+ * The copy is made while the lock is held, so the caller gets a
+ * consistent snapshot. */
+std::vector<domain::Client> CsvClientRepository::findAll() const {
+  std::lock_guard<std::mutex> lock(mtx_);
   return clients_;
 }
 
 void CsvClientRepository::updateClient(domain::Client updated) {
+  std::lock_guard<std::mutex> lock(mtx_);
   auto it = std::find_if(clients_.begin(), clients_.end(),
                          [&updated](const domain::Client& c) {
                            return c.getUuid() == updated.getUuid();
@@ -74,6 +87,7 @@ void CsvClientRepository::updateClient(domain::Client updated) {
 }
 
 void CsvClientRepository::load() {
+  std::lock_guard<std::mutex> lock(mtx_);
   std::vector<domain::Client> tmp_clients;
 
   if (std::filesystem::exists(filepath_)) {
@@ -93,6 +107,7 @@ void CsvClientRepository::load() {
 }
 
 void CsvClientRepository::save() const {
+  std::lock_guard<std::mutex> lock(mtx_);
   std::string tmp = filepath_ + ".tmp";
   {
     FileHandler out(tmp, std::ios::out);

--- a/src/data/csv_client_repository.hpp
+++ b/src/data/csv_client_repository.hpp
@@ -1,4 +1,6 @@
 #pragma once
+#include <mutex>
+
 #include "../domain/client.hpp"
 #include "../domain/i_client_repository.hpp"
 
@@ -15,9 +17,10 @@ class CsvClientRepository : public domain::IClientRepository {
       std::string_view uuid) const override;
   std::optional<domain::Client> findByEmail(
       std::string_view email) const override;
-  const std::vector<domain::Client>& findAll() const override;
+  std::vector<domain::Client> findAll() const override;
 
  private:
+  mutable std::mutex mtx_;
   void save() const override;
   bool isDirty() const override { return dirty_; }
   std::string serialize(const domain::Client& c) const;

--- a/src/data/csv_policy_repository.cpp
+++ b/src/data/csv_policy_repository.cpp
@@ -16,11 +16,13 @@ CsvPolicyRepository::CsvPolicyRepository(std::string filepath)
     : filepath_(std::move(filepath)) {}
 
 void CsvPolicyRepository::insertPolicy(domain::Policy policy) {
+  std::lock_guard<std::mutex> lock(mtx_);
   policies_.push_back(std::move(policy));
   dirty_ = true;
 }
 
 void CsvPolicyRepository::removePolicy(std::string_view uuid) {
+  std::lock_guard<std::mutex> lock(mtx_);
   auto it = std::remove_if(
       policies_.begin(), policies_.end(),
       [uuid](const domain::Policy& p) { return p.getUuid() == uuid; });
@@ -32,6 +34,7 @@ void CsvPolicyRepository::removePolicy(std::string_view uuid) {
 
 std::optional<domain::Policy> CsvPolicyRepository::findByUuid(
     std::string_view uuid) const {
+  std::lock_guard<std::mutex> lock(mtx_);
   auto it = std::find_if(
       policies_.begin(), policies_.end(),
       [uuid](const domain::Policy& p) { return p.getUuid() == uuid; });
@@ -42,6 +45,7 @@ std::optional<domain::Policy> CsvPolicyRepository::findByUuid(
 
 std::vector<domain::Policy> CsvPolicyRepository::findByClientUuid(
     std::string_view client_uuid) const {
+  std::lock_guard<std::mutex> lock(mtx_);
   std::vector<domain::Policy> found;
 
   std::copy_if(policies_.begin(), policies_.end(), std::back_inserter(found),
@@ -52,12 +56,20 @@ std::vector<domain::Policy> CsvPolicyRepository::findByClientUuid(
   return found;
 }
 
-const std::vector<domain::Policy>& CsvPolicyRepository::findAll() const {
+/* Returns by value, not by reference. Returning a reference would
+ * allow the caller to hold a pointer into the internal vector after
+ * the mutex is released. Any write from another thread that triggers
+ * reallocation would invalidate that pointer (undefined behavior).
+ * The copy is made while the lock is held, so the caller gets a
+ * consistent snapshot. */
+std::vector<domain::Policy> CsvPolicyRepository::findAll() const {
+  std::lock_guard<std::mutex> lock(mtx_);
   return policies_;
 }
 
 std::vector<domain::Policy> CsvPolicyRepository::findWhere(
     const domain::PolicyFilter& filter) const {
+  std::lock_guard<std::mutex> lock(mtx_);
   std::vector<domain::Policy> found;
 
   std::copy_if(
@@ -77,6 +89,7 @@ std::vector<domain::Policy> CsvPolicyRepository::findWhere(
 }
 
 void CsvPolicyRepository::updatePolicy(domain::Policy updated) {
+  std::lock_guard<std::mutex> lock(mtx_);
   auto it = std::find_if(policies_.begin(), policies_.end(),
                          [&updated](const domain::Policy& p) {
                            return p.getUuid() == updated.getUuid();
@@ -139,6 +152,7 @@ domain::Policy CsvPolicyRepository::deserialize(const std::string& line) const {
  */
 
 void CsvPolicyRepository::load() {
+  std::lock_guard<std::mutex> lock(mtx_);
   std::vector<domain::Policy> tmp_policies;
 
   if (std::filesystem::exists(filepath_)) {
@@ -156,6 +170,7 @@ void CsvPolicyRepository::load() {
 }
 
 void CsvPolicyRepository::save() const {
+  std::lock_guard<std::mutex> lock(mtx_);
   std::string tmp = filepath_ + ".tmp";
   {
     /* Scoped because destructor needs to run */

--- a/src/data/csv_policy_repository.hpp
+++ b/src/data/csv_policy_repository.hpp
@@ -1,4 +1,6 @@
 #pragma once
+#include <mutex>
+
 #include "../domain/i_policy_repository.hpp"
 #include "../domain/policy.hpp"
 
@@ -19,7 +21,7 @@ class CsvPolicyRepository : public domain::IPolicyRepository {
   std::vector<domain::Policy> findWhere(
       const domain::PolicyFilter& filter) const override;
 
-  const std::vector<domain::Policy>& findAll() const override;
+  std::vector<domain::Policy> findAll() const override;
 
  private:
   void save() const override;
@@ -30,6 +32,7 @@ class CsvPolicyRepository : public domain::IPolicyRepository {
   std::vector<domain::Policy> policies_;
   std::string filepath_;
   mutable bool dirty_ = false;
+  mutable std::mutex mtx_;
 };
 
 }  // namespace insura::data

--- a/src/domain/i_client_repository.hpp
+++ b/src/domain/i_client_repository.hpp
@@ -78,7 +78,7 @@ class IClientRepository {
   virtual void updateClient(Client updated) = 0;
   virtual std::optional<Client> findByUuid(std::string_view uuid) const = 0;
   virtual std::optional<Client> findByEmail(std::string_view email) const = 0;
-  virtual const std::vector<Client>& findAll() const = 0;
+  virtual std::vector<Client> findAll() const = 0;
   virtual ~IClientRepository() = default;
 };
 

--- a/src/domain/i_policy_repository.hpp
+++ b/src/domain/i_policy_repository.hpp
@@ -42,7 +42,7 @@ class IPolicyRepository {
       std::string_view client_uuid) const = 0;
   virtual std::vector<Policy> findWhere(
       const PolicyFilter& filter) const = 0;
-  virtual const std::vector<Policy>& findAll() const = 0;
+  virtual std::vector<Policy> findAll() const = 0;
 
   virtual ~IPolicyRepository() = default;
 };

--- a/src/domain/utils.cpp
+++ b/src/domain/utils.cpp
@@ -4,6 +4,7 @@
 #include <cctype>
 #include <chrono>
 #include <ctime>
+#include <mutex>
 #include <iomanip>
 #include <random>
 #include <regex>
@@ -38,10 +39,12 @@ std::optional<std::string> stringToOptional(const std::string& s) {
 }
 
 std::string generateUuid() {
+  static std::mutex uuid_mtx;
   static std::random_device rd;
   static std::mt19937 mt(rd());
   static std::uniform_int_distribution<> dist(0, 15);
   static std::uniform_int_distribution<> dist2(8, 11);
+  std::lock_guard<std::mutex> lock(uuid_mtx);
 
   std::stringstream ss;
   int i;

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -9,6 +9,7 @@
 #include "./data/file_handle.hpp"
 #include "./domain/strops.hpp"
 #include "./domain/utils.hpp"
+#include "./service/auto_save_service.hpp"
 #include "./service/client_service.hpp"
 #include "./service/policy_service.hpp"
 
@@ -264,8 +265,10 @@ int main() {
   insura::service::PolicyService policy_service(*repos.policy_repo);
   insura::service::ClientService client_service(*repos.client_repo,
                                                 *repos.policy_repo);
-  insura::cli::Application app(client_service, *repos.client_repo,
-                               policy_service, *repos.policy_repo);
+
+  insura::cli::Application app(
+      config.autosave_enabled, config.autosave_interval_seconds, client_service,
+      *repos.client_repo, policy_service, *repos.policy_repo);
 
   app.run();
   return 0;

--- a/src/service/auto_save_service.cpp
+++ b/src/service/auto_save_service.cpp
@@ -1,0 +1,47 @@
+#include "auto_save_service.hpp"
+
+#include <chrono>
+#include <condition_variable>
+#include <mutex>
+
+namespace insura::service {
+
+AutoSaveService::~AutoSaveService() {
+  if (autosave_.joinable()) stop();
+}
+
+AutoSaveService::AutoSaveService(std::function<void()> save, int interval)
+    : save_(save), interval_(interval) {
+  start();
+}
+
+void AutoSaveService::start() {
+  autosave_ = std::thread([this]() {
+    while (!stop_flag_) {
+      std::unique_lock<std::mutex> lock(mtx_);
+      condv_.wait_for(lock, std::chrono::seconds(interval_),
+                      [this] { return stop_flag_.load(); });
+
+      if (stop_flag_) break;
+
+      /* calling unlock because here the mutex prevents only
+       * data races on the stop flag, each save function
+       * has its own mutex */
+      lock.unlock();
+
+      /* do the actual job */
+      save_();
+    }
+  });
+}
+
+void AutoSaveService::stop() {
+  std::unique_lock<std::mutex> lock(mtx_);
+  stop_flag_ = true;
+
+  lock.unlock();
+  condv_.notify_one();
+  if (autosave_.joinable()) autosave_.join();
+}
+
+}  // namespace insura::service

--- a/src/service/auto_save_service.hpp
+++ b/src/service/auto_save_service.hpp
@@ -1,0 +1,25 @@
+#pragma once
+
+#include <atomic>
+#include <condition_variable>
+#include <thread>
+namespace insura::service {
+
+class AutoSaveService {
+ public:
+  AutoSaveService(std::function<void()> save, int interval);
+  ~AutoSaveService();
+  void stop();
+
+ private:
+  void start();
+  std::function<void()> save_;
+  int interval_;
+
+  std::atomic<bool> stop_flag_{false};
+  std::mutex mtx_;
+  std::condition_variable condv_;
+  std::thread autosave_;
+};
+
+}  // namespace insura::service

--- a/src/service/policy_service.hpp
+++ b/src/service/policy_service.hpp
@@ -1,4 +1,5 @@
 #pragma once
+
 #include "../domain/i_policy_repository.hpp"
 #include "../domain/policy_data.hpp"
 


### PR DESCRIPTION
**Description**

Adds a background auto-save thread that periodically saves data to
disk without blocking the CLI. Includes thread safety across all
repository operations and UUID generation.

**Changes**

**AutoSaveService (new class in src/service/)**
- Background thread runs a loop using condition_variable::wait_for
  with configurable interval and atomic stop flag
- Control mutex released before calling save so repository I/O
  does not block the shutdown path
- stop() sets flag, unlocks, notifies, joins
- Destructor calls stop() as safety net for abnormal exit paths

**Repository thread safety**
- std::mutex added to CsvClientRepository and CsvPolicyRepository
- lock_guard on every method that reads or writes the data vector
- findAll changed from const reference to return by value, preventing
  dangling reference after lock release
- Mutex declared mutable for const methods

**UUID thread safety**
- std::mutex added around the shared static mt19937 engine in
  generateUuid

**Application wiring**
- AutoSaveService stored as std::optional, constructed only when
  config.autosave_enabled is true
- Constructor receives autosave_enabled and autosave_interval from
  config via main.cpp
- cmdSave takes a bool silent parameter so auto-save does not print
  to stdout (prevents output interleaving with user prompts)
- cmdExit calls stop() before checking dirty flag

**Config integration**
- autosave_enabled and autosave_interval_seconds from config struct
  now passed to Application constructor

**Architecture notes**

Three separate mutexes protect three independent concerns: client
data (inside CsvClientRepository), policy data (inside
CsvPolicyRepository), auto-save control state (inside
AutoSaveService). Design rationale documented in ADR-024.